### PR TITLE
Gradle config to check ktfmt before each commit on Android Studio

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -237,3 +237,26 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
 }
+
+tasks.register("beforeCommitCheck") {
+    dependsOn("ktfmtFormat", "ktfmtCheck")
+}
+
+tasks.named("ktfmtCheck") {
+    mustRunAfter("ktfmtFormat")
+}
+
+tasks.named("ktfmtCheckAndroidTest") {
+    dependsOn("ktfmtFormatAndroidTest")
+    mustRunAfter("ktfmtFormatAndroidTest")
+}
+
+tasks.named("ktfmtCheckMain") {
+    dependsOn("ktfmtFormatMain")
+    mustRunAfter("ktfmtFormatMain")
+}
+
+tasks.named("ktfmtCheckTest") {
+    dependsOn("ktfmtFormatTest")
+    mustRunAfter("ktfmtFormatTest")
+}


### PR DESCRIPTION
The goal of this PR is to add a config, that creates a gradle task. It can be configured to run before each commit on android studio, avoiding unnecessary failures of CI pipelines.