### PR TITLE
fix(apk): add id to create release to upload asset

### DIFF
--- a/.github/workflows/apk.yml
+++ b/.github/workflows/apk.yml
@@ -54,11 +54,12 @@ jobs:
           #path: app/build/outputs/apk/release/*.apk
           path: app/build/outputs/apk/debug/*.apk
       - name: Create GitHub release
+        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
         with:
-          tag_name: ${{ github.run_number}}
+          tag_name: ${{ github.event.inputs.name }}
           release_name: ${{ github.event.inputs.name }} (#${{ github.run_number}})
       - name: Upload Release Asset
         id: upload-release-asset


### PR DESCRIPTION
Added id to "Create GitHub release" to reference an url in upload_url in the Upload Release Asset