### PR TITLE
ci(apk): change permissions from write-all to write

### DIFF
--- a/.github/workflows/apk.yml
+++ b/.github/workflows/apk.yml
@@ -12,7 +12,7 @@ on:
       - 'v*'
         
 permissions:
-  contents: write-all
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
The CI fails for unrecognize permissions. Changed write-all to write.