### PR TITLE
ci(apk): change tagname in release

### DIFF
--- a/.github/workflows/apk.yml
+++ b/.github/workflows/apk.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
         with:
-          tag_name: ${{ github.event.inputs.name }}
+          tag_name: ${{ github.run_number}}
           release_name: ${{ github.event.inputs.name }} (#${{ github.run_number}})
           draft: false
           prerelease: false


### PR DESCRIPTION
Changed the tagname in the release because the last tagname was not recognized as valid.