### PR TITLE
Fix of the CI fail due to tests of documents

### DIFF
--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/documents/DocumentListTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/documents/DocumentListTest.kt
@@ -69,7 +69,7 @@ class DocumentListTest {
       it.getArgument<(List<DocumentContainer>) -> Unit>(0)(list_documents)
     }
 
-    composeTestRule.setContent { DocumentList(mockDocumentViewModel, navigationActions, {}) }
+    composeTestRule.setContent { DocumentListScreen(mockDocumentViewModel, navigationActions, {}) }
 
     composeTestRule.onNodeWithTag("documentListScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("documentListTitle").assertIsDisplayed()


### PR DESCRIPTION
fix: due to refactoring DocumentList does not exist, so tests fail (and the CI). So replacing DocumentList by DocumentListScreen (its new name)