### PR TITLE
Ci: Release build for CI 

### DIFF
--- a/.github/workflows/apk.yml
+++ b/.github/workflows/apk.yml
@@ -1,16 +1,16 @@
-name: Android Build
+name: Android Release Build
 
 on:
   workflow_dispatch:
     inputs:
       name:
         description: "Ex: milestone name"
-        default: "Mn"
+        default: "TestRelease"
         required: true
   push:
     tags:
       - 'v*'
-        
+
 permissions:
   contents: write
 
@@ -23,39 +23,43 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-        # Load google-services.json and local.properties from the secrets
-      - name: Decode secrets
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      # Load google-services.json and local.properties from the secrets
+      - name: Decode google-services.json
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-          # LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
 
       - name: Set permissions for google-services.json
         run: chmod 644 ./app/google-services.json
 
-      - name: Set executable permissions for gradlew
-        run: chmod +x ./gradlew
-
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'  # Use Zulu OpenJDK
-          java-version: '17'
-
-      - name: Install dependencies
-        run: ./gradlew dependencies
-
-      - name: Build APK Debug
-        run: ./gradlew assembleDebug
-
-      - name: Extract SHA-1 Fingerprint from Debug Keystore
+      # Generate a test keystore if not available
+      - name: Generate Release Keystore if Missing
         run: |
-            keytool -list -v \
-              -keystore $HOME/.android/debug.keystore \
-              -alias androiddebugkey \
-              -storepass android \
-              -keypass android | grep 'SHA1'
+          if [ ! -f "~/test-release.keystore" ]; then
+            keytool -genkey -v -keystore ~/test-release.keystore -alias testalias \
+              -storepass testpass -keypass testpass -keyalg RSA -validity 10000 \
+              -dname "CN=Test Release,O=Testing,C=US"
+          fi
+
+      - name: Build APK Release with Custom Key
+        run: ./gradlew assembleRelease
+
+      - name: Extract SHA-1 fingerprint from Release Keystore
+        id: extract_sha
+        run: |
+          SHA1=$(keytool -list -v \
+              -keystore ~/test-release.keystore \
+              -alias testalias \
+              -storepass testpass | grep 'SHA1' | awk '{print $2}')
+          echo "SHA1=${SHA1}" >> $GITHUB_ENV
+          echo "SHA1 fingerprint: ${SHA1}"
 
       - name: List APK files
         run: |
@@ -64,19 +68,20 @@ jobs:
       - name: Upload APK
         uses: actions/upload-artifact@v3
         with:
-          name: "${{ github.event.inputs.name }}-Debug-APK"
-          #path: app/build/outputs/apk/release/*.apk
-          path: app/build/outputs/apk/debug/*.apk
+          name: "${{ github.event.inputs.name }}-Release-APK"
+          path: app/build/outputs/apk/release/*.apk
+
       - name: Create GitHub release
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.run_number}}
-          release_name: ${{ github.event.inputs.name }} (#${{ github.run_number}})
+          tag_name: ${{ github.run_number }}
+          release_name: ${{ github.event.inputs.name }} (#${{ github.run_number }})
           draft: false
           prerelease: false
+
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -84,6 +89,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: app/build/outputs/apk/debug/app-debug.apk
-          asset_name: TravelPouch.apk
+          asset_path: app/build/outputs/apk/release/app-release.apk
+          asset_name: TravelPouch-Release.apk
           asset_content_type: application/vnd.android.package-archive

--- a/.github/workflows/apk.yml
+++ b/.github/workflows/apk.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       name:
-        description: "Ex: milestone name"
-        default: "TestRelease"
+        description: "Android APK Release"
+        default: "Android Release"
         required: true
   push:
     tags:
@@ -47,11 +47,25 @@ jobs:
               -storepass testpass -keypass testpass -keyalg RSA -validity 10000 \
               -dname "CN=Test Release,O=Testing,C=US"
           fi
+      # We must get the full path because the gradle will overwrite ~/
+      - name: Get full path of keystore and add to environment
+        id: get_keystore_path
+        run: |
+          KEYS_PATH=$(readlink -f ~/test-release.keystore)
+          echo "KEYSTORE_FILE=$KEYS_PATH" >> $GITHUB_ENV
+
 
       - name: Build APK Release with Custom Key
-        run: ./gradlew assembleRelease
+        env:
+          KEYSTORE_PASSWORD: testpass
+          KEY_ALIAS: testalias
+          KEY_PASSWORD: testpass
+        run: |
+          echo "Keystore_file is: $KEYSTORE_FILE" && \
+          echo "readlink of keystore is:" \
+          && echo $(readlink -f ~/test-release.keystore) && ./gradlew clean assembleRelease --info
 
-      - name: Extract SHA-1 fingerprint from Release Keystore
+      - name: Extract SHA-1 Fingerprint from Release Keystore
         id: extract_sha
         run: |
           SHA1=$(keytool -list -v \

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,10 +38,21 @@ android {
             useSupportLibrary = true
         }
     }
+    signingConfigs {
+        // Ensure debug signing config exists or create a new one
+        create("release") {
+            storeFile = file(System.getProperty("user.home") + "/test-release.keystore") // Use custom keystore here
+            storePassword = "testpass" // Change this to your keystore password
+            keyAlias = "testalias" // Alias used in the keystore
+            keyPassword = "testpass" // Key password
+        }
+    }
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            signingConfig = signingConfigs.getByName("release")
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,17 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+# Firebase UI Auth rules
+-keep class com.firebase.ui.auth.** { *; }
+-keep class com.google.android.gms.auth.api.credentials.** { *; }
+-keep class com.google.android.gms.tasks.** { *; }
+
+# General rules for Google Play Services
+-dontwarn com.google.android.gms.**
+-keep class androidx.** { *; }
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
+-keepattributes *Annotation*
+-dontwarn okhttp3.**
+-keep class okhttp3.** { *; }


### PR DESCRIPTION
Modified .apk workflow to build a release of the application and prints SHA-1 fingerprint.

Fingerprint is needed for Google Sign-in, and proguard-rules.pro and build.gradle.kts minimize the size of the resulting apk.
One needs to manually upload the sha-1 digest to Firestore for Google Sign-in to work.

Other release options such as performance optimizations and size reduction were also added. 

Closes #84 