### PR TITLE
Add a Participant and copy email to clipboard buttons

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     val keystorePassword = System.getenv("KEYSTORE_PASSWORD") ?: localProperties.getProperty("KEYSTORE_PASSWORD")
     val keyAlias = System.getenv("KEY_ALIAS") ?: localProperties.getProperty("KEY_ALIAS")
     val keyPassword = System.getenv("KEY_PASSWORD") ?: localProperties.getProperty("KEY_PASSWORD")
-    val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
+    val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: (System.getenv("MAPS_API_KEY") ?: "")
 
     defaultConfig {
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey

--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/travel/EditTravelScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/travel/EditTravelScreenTest.kt
@@ -143,8 +143,21 @@ class EditTravelSettingsScreenTest {
     val travelContainer = createContainer()
     listTravelViewModel.selectTravel(travelContainer)
     composeTestRule.setContent { EditTravelSettingsScreen(listTravelViewModel, navigationActions) }
-    composeTestRule.onNodeWithTag("addUserFab").performClick()
     composeTestRule.onNodeWithTag("importEmailFab").performClick()
+    composeTestRule.onNodeWithTag("addUserFab").performClick()
+
+    // perform add user
+    // Check that the dialog is displayed
+    composeTestRule.onNodeWithTag("roleDialogColumn").assertIsDisplayed()
+    // Check that the title text is displayed and correct
+    composeTestRule.onNodeWithTag("addUserDialogTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addUserDialogTitle").assertTextEquals("Add User by Email")
+    // Check that the OutlinedTextField is displayed and has the correct default value
+    composeTestRule.onNodeWithTag("addUserEmailField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addUserEmailField").assertTextContains("newuser.email@example.org")
+    val randomEmail = "random.email@example.org"
+    inputText("addUserEmailField", "newuser.email@example.org", randomEmail)
+    composeTestRule.onNodeWithTag("addUserButton").performClick()
     composeTestRule.onNodeWithTag("travelDeleteButton").performClick()
     doNothing().`when`(navigationActions).goBack()
     composeTestRule.onNodeWithTag("travelSaveButton").performClick()

--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/travel/EditTravelScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/travel/EditTravelScreenTest.kt
@@ -16,11 +16,13 @@ import com.github.se.travelpouch.model.Participant
 import com.github.se.travelpouch.model.Role
 import com.github.se.travelpouch.model.TravelContainer
 import com.github.se.travelpouch.model.TravelRepository
+import com.github.se.travelpouch.model.UserInfo
 import com.github.se.travelpouch.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
@@ -141,6 +143,12 @@ class EditTravelSettingsScreenTest {
   @Test
   fun pressALotOfButtons() {
     val travelContainer = createContainer()
+    val customUserInfo =
+        UserInfo(
+            "abcdefghijklmnopqstu",
+            "Custom User",
+            listOf("00000000000000000000"),
+            "newuser.email@example.org")
     listTravelViewModel.selectTravel(travelContainer)
     composeTestRule.setContent { EditTravelSettingsScreen(listTravelViewModel, navigationActions) }
     composeTestRule.onNodeWithTag("importEmailFab").performClick()
@@ -154,10 +162,49 @@ class EditTravelSettingsScreenTest {
     composeTestRule.onNodeWithTag("addUserDialogTitle").assertTextEquals("Add User by Email")
     // Check that the OutlinedTextField is displayed and has the correct default value
     composeTestRule.onNodeWithTag("addUserEmailField").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("addUserEmailField").assertTextContains("newuser.email@example.org")
+    composeTestRule
+        .onNodeWithTag("addUserEmailField")
+        .assertTextContains("newuser.email@example.org")
     val randomEmail = "random.email@example.org"
     inputText("addUserEmailField", "newuser.email@example.org", randomEmail)
+    // Now this is an invalid user that doesn't exist
+    doAnswer { invocation ->
+          val onFailure = invocation.getArgument<(Exception) -> Unit>(2)
+          onFailure(Exception("User not found"))
+        }
+        .`when`(travelRepository)
+        .checkParticipantExists(any(), any(), any())
     composeTestRule.onNodeWithTag("addUserButton").performClick()
+
+    // Now this is a valid user that had serialisation problems
+    inputText("addUserEmailField", randomEmail, "newuser.email@example.org")
+    doAnswer { invocation ->
+          val onSuccess = invocation.getArgument<(UserInfo?) -> Unit>(1)
+          // Call the onSuccess callback with null
+          onSuccess(null)
+        }
+        .`when`(travelRepository)
+        .checkParticipantExists(any(), any(), any())
+    // Mock the repository.updateTravel method to do nothing
+    doNothing().`when`(travelRepository).updateTravel(any(), any(), any())
+    composeTestRule.onNodeWithTag("addUserButton").performClick()
+
+    // Now this is a valid user that does exist
+    doAnswer { invocation ->
+          val email = invocation.getArgument<String>(0)
+          val onSuccess = invocation.getArgument<(UserInfo?) -> Unit>(1)
+          val customUserInfo =
+              UserInfo("abcdefghijklmnopqstu", "Custom User", listOf("00000000000000000000"), email)
+          // Call the onSuccess callback with the custom UserInfo
+          onSuccess(customUserInfo)
+        }
+        .`when`(travelRepository)
+        .checkParticipantExists(any(), any(), any())
+    // Mock the repository.updateTravel method to do nothing
+    doNothing().`when`(travelRepository).updateTravel(any(), any(), any())
+    composeTestRule.onNodeWithTag("addUserButton").performClick()
+
+    // perform deletion of travel
     composeTestRule.onNodeWithTag("travelDeleteButton").performClick()
     doNothing().`when`(navigationActions).goBack()
     composeTestRule.onNodeWithTag("travelSaveButton").performClick()

--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/travel/EditTravelScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/travel/EditTravelScreenTest.kt
@@ -143,12 +143,6 @@ class EditTravelSettingsScreenTest {
   @Test
   fun pressALotOfButtons() {
     val travelContainer = createContainer()
-    val customUserInfo =
-        UserInfo(
-            "abcdefghijklmnopqstu",
-            "Custom User",
-            listOf("00000000000000000000"),
-            "newuser.email@example.org")
     listTravelViewModel.selectTravel(travelContainer)
     composeTestRule.setContent { EditTravelSettingsScreen(listTravelViewModel, navigationActions) }
     composeTestRule.onNodeWithTag("importEmailFab").performClick()

--- a/app/src/main/java/com/github/se/travelpouch/model/ListTravelViewModel.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/ListTravelViewModel.kt
@@ -52,7 +52,16 @@ open class ListTravelViewModel(private val repository: TravelRepository) : ViewM
   fun getNewUid(): String {
     return repository.getNewUid()
   }
-
+  /**
+   * Fetches participant information from the repository using their unique ID.
+   *
+   * This function queries the repository to retrieve the participant's information based on the
+   * provided unique ID (`fsUid`). If the participant is found, their information is added to the
+   * `participants_` state. If the participant is not found or an error occurs, appropriate log
+   * messages are generated.
+   *
+   * @param fsUid The unique ID of the participant to be fetched.
+   */
   private fun getParticipantFromfsUid(fsUid: fsUid) {
     repository.getParticipantFromfsUid(
         fsUid = fsUid,
@@ -63,6 +72,43 @@ open class ListTravelViewModel(private val repository: TravelRepository) : ViewM
           } ?: Log.d("ListTravelViewModel", "$fsUid is null")
         },
         onFailure = { Log.e("ListTravelViewModel", "Failed to get participant", it) })
+  }
+  /**
+   * Checks if a participant with the given email exists.
+   *
+   * This function queries the repository to check if a participant with the specified email exists.
+   * If the participant exists, the `onSuccess` callback is invoked with the `UserInfo` of the
+   * participant. If the participant does not exist or an error occurs, the `onFailure` callback is
+   * invoked.
+   *
+   * @param email The email of the participant to check.
+   * @param onSuccess A callback function to be invoked with the `UserInfo` of the participant if
+   *   they exist.
+   * @param onFailure A callback function to be invoked if the participant does not exist or an
+   *   error occurs.
+   */
+  private fun checkParticipantExists(
+      email: String,
+      onSuccess: (UserInfo) -> Unit,
+      onFailure: () -> Unit
+  ) {
+    repository.checkParticipantExists(
+        email = email,
+        onSuccess = { user ->
+          if (user != null) {
+            Log.d("ListTravelViewModel", "${user.name} is not null for $email")
+            onSuccess(user)
+          } else {
+            Log.e(
+                "ListTravelViewModel",
+                "$email user is null, means it was not found or there are multiple users with the same email")
+            onFailure()
+          }
+        },
+        onFailure = {
+          Log.e("ListTravelViewModel", "Failed to check participant", it)
+          onFailure()
+        })
   }
 
   /** Gets all Travel documents. */
@@ -150,5 +196,38 @@ open class ListTravelViewModel(private val repository: TravelRepository) : ViewM
           "ListTravelViewModel",
           "lastFetchedParticipants: $lastFetchedParticipants and currentParticipants: $currentParticipants")
     }
+  }
+  /**
+   * Adds a user to the selected travel by their email.
+   *
+   * This function first checks if a participant with the given email exists. If the participant
+   * exists, they are added to the `allParticipants` map of the selected travel with the role of
+   * `PARTICIPANT`. The updated travel document is then saved, and the `onSuccess` callback is
+   * invoked with the updated travel document. If the participant does not exist or an error occurs,
+   * the `onFailure` callback is invoked.
+   *
+   * @param email The email of the user to be added.
+   * @param selectedTravel The travel document to which the user will be added.
+   * @param onSuccess A callback function to be invoked with the updated travel document upon
+   *   successful addition.
+   * @param onFailure A callback function to be invoked if the addition fails.
+   */
+  fun addUserToTravel(
+      email: String,
+      selectedTravel: TravelContainer,
+      onSuccess: (TravelContainer) -> Unit,
+      onFailure: () -> Unit
+  ) {
+    checkParticipantExists(
+        email,
+        onSuccess = { user ->
+          val newParticipant = Participant(user.fsUid)
+          val newParticipantMap = selectedTravel.allParticipants.toMutableMap()
+          newParticipantMap[newParticipant] = Role.PARTICIPANT
+          val newTravel = selectedTravel.copy(allParticipants = newParticipantMap.toMap())
+          updateTravel(newTravel)
+          onSuccess(newTravel)
+        },
+        onFailure = { onFailure() })
   }
 }

--- a/app/src/main/java/com/github/se/travelpouch/model/TravelRepository.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/TravelRepository.kt
@@ -10,6 +10,12 @@ interface TravelRepository {
       onFailure: (Exception) -> Unit
   )
 
+  fun checkParticipantExists(
+      email: String,
+      onSuccess: (UserInfo?) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
   fun init(onSuccess: () -> Unit)
 
   fun getTravels(onSuccess: (List<TravelContainer>) -> Unit, onFailure: (Exception) -> Unit)

--- a/app/src/main/java/com/github/se/travelpouch/model/TravelRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/TravelRepositoryFirestore.kt
@@ -83,29 +83,29 @@ class TravelRepositoryFirestore(
       onSuccess: (UserInfo?) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    db.collection(userCollectionPath).whereEqualTo("email", email).get().addOnCompleteListener {
-        task ->
-      if (task.isSuccessful) {
-        Log.d("TravelRepositoryFirestore", "checkParticipantExists success ${task.result.isEmpty}")
-        val user =
-            task.result?.let { userEntries ->
-              if (userEntries.isEmpty) {
-                null
-              } else {
-                if (userEntries.size() > 1) {
-                  Log.e("TravelRepositoryFirestore", "Multiple users with same email")
+    db.collection(userCollectionPath)
+        .whereEqualTo("email", email)
+        .get()
+        .addOnSuccessListener { userEntries ->
+          Log.d(
+              "TravelRepositoryFirestore", "checkParticipantExists success ${userEntries.isEmpty}")
+          val user =
+              userEntries?.let {
+                if (userEntries.isEmpty) {
+                  null
+                } else {
+                  if (userEntries.size() > 1) {
+                    Log.e("TravelRepositoryFirestore", "Multiple users with same email")
+                  }
+                  documentToUserInfo(userEntries.documents[0])
                 }
-                documentToUserInfo(userEntries.documents[0])
               }
-            }
-        onSuccess(user)
-      } else {
-        task.exception?.let { e ->
-          Log.e("TravelRepositoryFirestore", "API error checking participant existence", e)
-          onFailure(e)
+          onSuccess(user)
         }
-      }
-    }
+        .addOnFailureListener {
+          Log.e("TravelRepositoryFirestore", "API error checking participant existence", it)
+          onFailure(it)
+        }
   }
 
   /**

--- a/app/src/main/java/com/github/se/travelpouch/model/TravelRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/TravelRepositoryFirestore.kt
@@ -83,29 +83,29 @@ class TravelRepositoryFirestore(
       onSuccess: (UserInfo?) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    db.collection(userCollectionPath)
-        .whereEqualTo("email", email)
-        .get()
-        .addOnSuccessListener { userEntries ->
-          Log.d(
-              "TravelRepositoryFirestore", "checkParticipantExists success ${userEntries.isEmpty}")
-          val user =
-              userEntries?.let {
-                if (userEntries.isEmpty) {
-                  null
-                } else {
-                  if (userEntries.size() > 1) {
-                    Log.e("TravelRepositoryFirestore", "Multiple users with same email")
-                  }
-                  documentToUserInfo(userEntries.documents[0])
+    db.collection(userCollectionPath).whereEqualTo("email", email).get().addOnCompleteListener {
+        task ->
+      if (task.isSuccessful) {
+        Log.d("TravelRepositoryFirestore", "checkParticipantExists success ${task.result.isEmpty}")
+        val user =
+            task.result?.let { userEntries ->
+              if (userEntries.isEmpty) {
+                null
+              } else {
+                if (userEntries.size() > 1) {
+                  Log.e("TravelRepositoryFirestore", "Multiple users with same email")
                 }
+                documentToUserInfo(userEntries.documents[0])
               }
-          onSuccess(user)
+            }
+        onSuccess(user)
+      } else {
+        task.exception?.let { e ->
+          Log.e("TravelRepositoryFirestore", "API error checking participant existence", e)
+          onFailure(e)
         }
-        .addOnFailureListener {
-          Log.e("TravelRepositoryFirestore", "API error checking participant existence", it)
-          onFailure(it)
-        }
+      }
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/se/travelpouch/ui/travel/EditTravelSettings.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/travel/EditTravelSettings.kt
@@ -294,7 +294,7 @@ fun EditTravelSettingsScreen(
       Dialog(onDismissRequest = { setExpandedAddUserDialog(false) }) {
         Box(Modifier.size(800.dp, 250.dp).background(Color.White).testTag("addUserDialogBox")) {
           Column(
-              modifier = Modifier.fillMaxSize().padding(16.dp).testTag("roleDialogColumn"),
+              modifier = Modifier.fillMaxSize().padding(16.dp).verticalScroll(rememberScrollState()).testTag("roleDialogColumn"),
               horizontalAlignment = Alignment.CenterHorizontally,
               verticalArrangement = Arrangement.Center) {
                 Text(

--- a/app/src/main/java/com/github/se/travelpouch/ui/travel/EditTravelSettings.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/travel/EditTravelSettings.kt
@@ -294,7 +294,11 @@ fun EditTravelSettingsScreen(
       Dialog(onDismissRequest = { setExpandedAddUserDialog(false) }) {
         Box(Modifier.size(800.dp, 250.dp).background(Color.White).testTag("addUserDialogBox")) {
           Column(
-              modifier = Modifier.fillMaxSize().padding(16.dp).verticalScroll(rememberScrollState()).testTag("roleDialogColumn"),
+              modifier =
+                  Modifier.fillMaxSize()
+                      .padding(16.dp)
+                      .verticalScroll(rememberScrollState())
+                      .testTag("roleDialogColumn"),
               horizontalAlignment = Alignment.CenterHorizontally,
               verticalArrangement = Arrangement.Center) {
                 Text(

--- a/app/src/main/java/com/github/se/travelpouch/ui/travel/ParticipantRow.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/travel/ParticipantRow.kt
@@ -1,6 +1,5 @@
 package com.github.se.travelpouch.ui.travel
 
-import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -31,11 +30,7 @@ fun ParticipantRow(
   val context = LocalContext.current
 
   Row(
-      modifier =
-          Modifier.fillMaxWidth().testTag("participantRow").clickable {
-            onClick()
-            Toast.makeText(context, "Participant clicked", Toast.LENGTH_SHORT).show()
-          },
+      modifier = Modifier.fillMaxWidth().testTag("participantRow").clickable { onClick() },
       horizontalArrangement = Arrangement.SpaceBetween,
       verticalAlignment = Alignment.CenterVertically) {
         Icon(


### PR DESCRIPTION
Adding a participant had been dropped for M1 due to time considerations.
Now, one can update a travel by adding a user by specifying its email address.
We scan firestore for the user with the given email.

Tests remain to be written in order to acheive sufficient coverage.
