### PR TITLE
Add google maps api key for APK

### DIFF
--- a/.github/workflows/apk.yml
+++ b/.github/workflows/apk.yml
@@ -29,12 +29,15 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
-      # Load google-services.json and local.properties from the secrets
-      - name: Decode google-services.json
+      # Load google-services.json
+      - name: Decode google-services.json and google maps api key and add to system env
         env:
+          GOOGLE_MAPS_API_KEY: ${{secrets.GOOGLE_MAPS_API_KEY}}
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          MAPS_API_KEY=$(echo "$GOOGLE_MAPS_API_KEY" | base64 --decode)
+          echo "MAPS_API_KEY=$MAPS_API_KEY" >> $GITHUB_ENV
 
       - name: Set permissions for google-services.json
         run: chmod 644 ./app/google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     val keystorePassword = System.getenv("KEYSTORE_PASSWORD") ?: localProperties.getProperty("KEYSTORE_PASSWORD")
     val keyAlias = System.getenv("KEY_ALIAS") ?: localProperties.getProperty("KEY_ALIAS")
     val keyPassword = System.getenv("KEY_PASSWORD") ?: localProperties.getProperty("KEY_PASSWORD")
-    val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
+    val mapsApiKey: String = System.getenv("MAPS_API_KEY") ?: localProperties.getProperty("MAPS_API_KEY")
 
     defaultConfig {
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey


### PR DESCRIPTION
Add google map API key when building the APK.
This is needed in order to make the map on the overview screen work properly.
This adds it as an environment variable in order for it to be passed when building the APK.