### PR TITLE
fix: replace `fun init()` with `init {}` block

### DIFF
--- a/app/src/main/java/com/github/se/travelpouch/model/activity/ActivityViewModel.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/activity/ActivityViewModel.kt
@@ -38,7 +38,7 @@ class ActivityViewModel(val activityRepositoryFirebase: ActivityRepository) : Vi
   private val onFailureTag = "ActivityViewModel"
 
   /** This is the initialisation function of the model view */
-  fun init() {
+  init {
     activityRepositoryFirebase.init { getAllActivities() }
   }
 


### PR DESCRIPTION
This pull request corrects the initialization of the modelview for an activity by changing the 'fun init()' method with an 'init {}' block.