### PR TITLE
feat(banner): Make banner scrollable, bigger, center

### DIFF
--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/NextActivitiesBanner.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/NextActivitiesBanner.kt
@@ -1,19 +1,26 @@
 package com.github.se.travelpouch.ui.dashboard
 
+import android.content.res.Configuration
+import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -21,8 +28,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.github.se.travelpouch.model.activity.Activity
 import com.google.firebase.Timestamp
 
@@ -38,52 +47,70 @@ import com.google.firebase.Timestamp
 fun NextActivitiesBanner(
     activities: List<Activity>, // Your activity data model
     onDismiss: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    localConfig: Configuration = LocalConfiguration.current
 ) {
+  val screenSize =
+      if (localConfig.orientation == ORIENTATION_PORTRAIT) localConfig.screenHeightDp
+      else localConfig.screenWidthDp
+  val dismissButtonSize = (screenSize * 0.05).dp // 5% of the screen size
   val showOutline = remember { mutableStateOf(false) }
   // Filter activities due within the next 24 hours
   val reminderRange = 86400L // 2400 hours in milliseconds
   val nowTime = Timestamp.now().seconds
+
   val upcomingActivities =
-      activities.filter { activity ->
-        val timeDiff: Long = activity.date.seconds - nowTime
-        timeDiff in 0..reminderRange // 24 hours in milliseconds
-      }
+      activities
+          .filter { activity ->
+            val timeDiff: Long = activity.date.seconds - nowTime
+            timeDiff in 0..reminderRange // 24 hours in milliseconds
+          }
+          .sortedBy { it.date } // Sort by due time
 
   if (upcomingActivities.isNotEmpty()) {
     Box(
         modifier =
             modifier
-                .background(Color.Gray.copy(alpha = 0.8f), RoundedCornerShape(8.dp))
-                .clickable {
-                  // Set the outline on first tap
-                  showOutline.value = true
-                }
-                .padding(16.dp)
+                .heightIn(
+                    max =
+                        (0.3f * LocalConfiguration.current.screenHeightDp.dp.value)
+                            .dp) // 30% of screen height
+                .background(Color.Gray.copy(alpha = 0.9f), RoundedCornerShape(8.dp))
+                .clickable { showOutline.value = true } // Set the outline on first tap
+                .padding(horizontal = 16.dp)
                 .testTag("NextActivitiesBannerBox"),
         contentAlignment = Alignment.Center) {
-          Row(
-              verticalAlignment = Alignment.CenterVertically,
-              horizontalArrangement = Arrangement.SpaceBetween,
+          Column(
+              verticalArrangement =
+                  Arrangement.SpaceBetween, // Spread content with space in between
+              horizontalAlignment = Alignment.CenterHorizontally,
               modifier = Modifier.fillMaxWidth()) {
-                // Display upcoming activities
-                Box(modifier = Modifier.weight(1f)) {
-                  Text(
-                      text =
-                          "Next activities due: ${
-                            upcomingActivities.joinToString(", ") { it.title }
-                        } in the next 24 hours.",
-                      color = Color.White,
-                      maxLines =
-                          3, // Limit max lines if you want to restrict vertical growth as well
-                      modifier = Modifier.testTag("NextActivitiesBannerText"))
-                }
+                // Title
+                Text(
+                    text = "Upcoming Activities in the next 24 hours",
+                    color = Color.DarkGray,
+                    style = MaterialTheme.typography.titleLarge.copy(fontSize = 20.sp),
+                    modifier = Modifier.padding(bottom = 8.dp))
+
+                // Scrollable list of upcoming activities
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().weight(1f) // Fill available vertical space
+                    ) {
+                      items(upcomingActivities) { activity ->
+                        Text(
+                            text = "- ${activity.title}",
+                            color = Color.White,
+                            style = MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp),
+                            modifier = Modifier.padding(vertical = 4.dp).fillMaxWidth())
+                      }
+                    }
 
                 // Dismiss button
                 IconButton(
                     onClick = onDismiss,
                     modifier =
-                        Modifier.border(
+                        Modifier.size(dismissButtonSize)
+                            .border(
                                 width = if (showOutline.value) 2.dp else 0.dp,
                                 color = if (showOutline.value) Color.Black else Color.Transparent,
                                 shape = CircleShape)
@@ -95,7 +122,5 @@ fun NextActivitiesBanner(
                     }
               }
         }
-  } else {
-    onDismiss()
   }
 }

--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
@@ -27,7 +27,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.travelpouch.model.activity.Activity
@@ -111,8 +113,9 @@ fun TravelActivitiesScreen(
             }
       }) { pd ->
         Box(
-            modifier = Modifier.fillMaxSize().padding(pd) // Apply scaffold padding to the whole box
-            ) {
+            modifier =
+                Modifier.fillMaxSize().padding(pd), // Apply scaffold padding to the whole box
+            contentAlignment = Alignment.Center) {
               LazyColumn(
                   verticalArrangement = Arrangement.spacedBy(8.dp),
                   contentPadding = PaddingValues(vertical = 8.dp),
@@ -142,7 +145,7 @@ fun TravelActivitiesScreen(
                 NextActivitiesBanner(
                     activities = listOfActivities.value,
                     onDismiss = { showBanner.value = false },
-                )
+                    localConfig = LocalConfiguration.current)
               }
             }
       }


### PR DESCRIPTION
Copied from #117

Description:
The idea is to make the reminder banner bigger, in the middle of the screen and have a scrollable list of all upcoming activities in a nicer way.

Acceptance Criteria:

    Remind Banner UI:

    Centered view, taking up 30% of the screen height, constrained on the sides
    Scrollable column displaying all activities due in less than 24 hours.
    Individual entries are displayed with an dash in front of them

    Remind Banner Model:

    Activities that are to be displayed should be sorted in increasing order of due time.
