### PR TITLE
feat: UI display images in an activity

### DIFF
--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/dashboard/TravelActivityScreen.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/dashboard/TravelActivityScreen.kt
@@ -99,12 +99,12 @@ class TravelActivityScreen {
   }
 
   @Test
-  fun runDefaultErrorUIToCheckFailure(){
-      composeTestRule.setContent { DefaultErrorUI() }
+  fun runDefaultErrorUIToCheckFailure() {
+    composeTestRule.setContent { DefaultErrorUI() }
   }
 
-  fun runAsyncLoadingSpinner(){
-        composeTestRule.setContent { AdvancedImageDisplayWithEffects("https://epic.gamer.huh") }
+  fun runAsyncLoadingSpinner() {
+    composeTestRule.setContent { AdvancedImageDisplayWithEffects("https://epic.gamer.huh") }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/dashboard/TravelActivityScreen.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/dashboard/TravelActivityScreen.kt
@@ -21,7 +21,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 
-class TravelActivityScreen {
+class TravelActivityScreenCopy {
   private lateinit var mockActivityRepositoryFirebase: ActivityRepository
   private lateinit var mockActivityModelView: ActivityViewModel
   private lateinit var navigationActions: NavigationActions
@@ -90,12 +90,46 @@ class TravelActivityScreen {
   @Test
   fun verifyActivityCardWorksCorrectly() {
     val activity = activites_test[0]
-    composeTestRule.setContent { ActivityItem(activity, {}, LocalContext.current) }
-    Thread.sleep(500)
+    val images =
+        listOf(
+            "https://img.yumpu.com/30185842/1/500x640/afps-attestation-de-formation-aux-premiers-secours-programme-.jpg",
+            "https://wallpapercrafter.com/desktop6/1606440-architecture-buildings-city-downtown-finance-financial.jpg",
+            "https://assets.entrepreneur.com/content/3x2/2000/20151023204134-poker-game-gambling-gamble-cards-money-chips-game.jpeg")
+    composeTestRule.setContent { ActivityItem(activity, {}, LocalContext.current, images) }
+    composeTestRule.waitForIdle()
     composeTestRule.onNodeWithTag("activityItem").assertIsDisplayed()
     composeTestRule.onNodeWithTag("activityItem").assertTextContains(activity.title)
     composeTestRule.onNodeWithTag("activityItem").assertTextContains(activity.location.name)
     composeTestRule.onNodeWithTag("activityItem").assertTextContains("1/1/1970")
+    composeTestRule.onNodeWithTag("extraDocumentButton").assertIsDisplayed().performClick()
+  }
+
+  @Test
+  fun verify1ImageActivity() {
+    val activity = activites_test[0]
+    val images =
+        listOf(
+            "https://img.yumpu.com/30185842/1/500x640/afps-attestation-de-formation-aux-premiers-secours-programme-.jpg",
+            "https://wallpapercrafter.com/desktop6/1606440-architecture-buildings-city-downtown-finance-financial.jpg",
+            "https://assets.entrepreneur.com/content/3x2/2000/20151023204134-poker-game-gambling-gamble-cards-money-chips-game.jpeg")
+    composeTestRule.setContent {
+      ActivityItem(activity, {}, LocalContext.current, listOf(images[0]))
+    }
+    composeTestRule.waitForIdle()
+  }
+
+  @Test
+  fun verify2ImagesActivity() {
+    val activity = activites_test[0]
+    val images =
+        listOf(
+            "https://img.yumpu.com/30185842/1/500x640/afps-attestation-de-formation-aux-premiers-secours-programme-.jpg",
+            "https://wallpapercrafter.com/desktop6/1606440-architecture-buildings-city-downtown-finance-financial.jpg",
+            "https://assets.entrepreneur.com/content/3x2/2000/20151023204134-poker-game-gambling-gamble-cards-money-chips-game.jpeg")
+    composeTestRule.setContent {
+      ActivityItem(activity, {}, LocalContext.current, listOf(images[0], images[1]))
+    }
+    composeTestRule.waitForIdle()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/dashboard/TravelActivityScreen.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/dashboard/TravelActivityScreen.kt
@@ -1,5 +1,6 @@
 package com.github.se.travelpouch.ui.dashboard
 
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
@@ -89,13 +90,21 @@ class TravelActivityScreen {
   @Test
   fun verifyActivityCardWorksCorrectly() {
     val activity = activites_test[0]
-
-    composeTestRule.setContent { ActivityItem(activity) }
-
+    composeTestRule.setContent { ActivityItem(activity, {}, LocalContext.current) }
+    Thread.sleep(500)
     composeTestRule.onNodeWithTag("activityItem").assertIsDisplayed()
     composeTestRule.onNodeWithTag("activityItem").assertTextContains(activity.title)
     composeTestRule.onNodeWithTag("activityItem").assertTextContains(activity.location.name)
     composeTestRule.onNodeWithTag("activityItem").assertTextContains("1/1/1970")
+  }
+
+  @Test
+  fun runDefaultErrorUIToCheckFailure(){
+      composeTestRule.setContent { DefaultErrorUI() }
+  }
+
+  fun runAsyncLoadingSpinner(){
+        composeTestRule.setContent { AdvancedImageDisplayWithEffects("https://epic.gamer.huh") }
   }
 
   @Test

--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
@@ -180,6 +180,7 @@ fun TravelActivitiesScreen(
 @Composable
 fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.content.Context) {
   val calendar = GregorianCalendar().apply { time = activity.date.toDate() }
+    // we hardcode for the moment placeholder images
   val images =
       listOf(
           "https://img.yumpu.com/30185842/1/500x640/afps-attestation-de-formation-aux-premiers-secours-programme-.jpg",
@@ -200,7 +201,7 @@ fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.
           if (images.isEmpty()) {
             // No images to show, do nothing
           } else if (images.size == 1) {
-            // Single image - crop to A4 aspect ratio
+            // Single image
             Box(
                 modifier =
                     Modifier.fillMaxWidth() // Fill the width of the parent
@@ -213,7 +214,7 @@ fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.
                       errorContent = { DefaultErrorUI() })
                 }
           } else if (images.size == 2) {
-            // Two images - display side by side with a vertical separator
+            // Two images - display side by side with space in between
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -234,7 +235,7 @@ fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.
           } else if (images.size >= 3) {
             // Three or more images - show the first two with a button above them
             Column(modifier = Modifier.fillMaxWidth()) {
-              Box { // Use Box to layer the images and the button
+              Box { // Box to layer
                 // Display the first two images inside a Row
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -263,7 +264,7 @@ fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.
                           .show()
                     },
                     modifier =
-                        Modifier.align(Alignment.BottomEnd) // Position the button on the top right
+                        Modifier.align(Alignment.BottomEnd) // Position the button on the bottom right
                             .background(
                                 Color.Gray,
                                 shape =

--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
@@ -74,7 +74,11 @@ fun TravelActivitiesScreen(
 
   val showBanner = remember { mutableStateOf(true) }
   val listOfActivities = activityModelView.activities.collectAsState()
-
+  val images =
+      listOf(
+          "https://img.yumpu.com/30185842/1/500x640/afps-attestation-de-formation-aux-premiers-secours-programme-.jpg",
+          "https://wallpapercrafter.com/desktop6/1606440-architecture-buildings-city-downtown-finance-financial.jpg",
+          "https://assets.entrepreneur.com/content/3x2/2000/20151023204134-poker-game-gambling-gamble-cards-money-chips-game.jpeg")
   Scaffold(
       modifier = Modifier.testTag("travelActivitiesScreen"),
       topBar = {
@@ -156,7 +160,8 @@ fun TravelActivitiesScreen(
                               activityModelView.selectActivity(listOfActivities.value[idx])
                               navigationActions.navigateTo(Screen.EDIT_ACTIVITY)
                             },
-                            LocalContext.current)
+                            LocalContext.current,
+                            images)
                       }
                     }
                   }
@@ -172,20 +177,22 @@ fun TravelActivitiesScreen(
 }
 
 /**
- * This function displays the date of an activity, its title, its location and first 2 images.
+ * Composable function to display an activity item.
  *
- * @param activity (Activity) : the activity to display
- * @param onClick (() -> Unit) : the function to apply when we click on an activity.
+ * @param activity The activity to display.
+ * @param onClick Lambda function to handle click events on the activity item.
+ * @param context The context in which the composable is called.
+ * @param images A list of image URLs to display for the activity.
  */
 @Composable
-fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.content.Context) {
+fun ActivityItem(
+    activity: Activity,
+    onClick: () -> Unit = {},
+    context: android.content.Context,
+    images: List<String>
+) {
   val calendar = GregorianCalendar().apply { time = activity.date.toDate() }
   // we hardcode for the moment placeholder images
-  val images =
-      listOf(
-          "https://img.yumpu.com/30185842/1/500x640/afps-attestation-de-formation-aux-premiers-secours-programme-.jpg",
-          "https://wallpapercrafter.com/desktop6/1606440-architecture-buildings-city-downtown-finance-financial.jpg",
-          "https://assets.entrepreneur.com/content/3x2/2000/20151023204134-poker-game-gambling-gamble-cards-money-chips-game.jpeg")
   Card(
       modifier = Modifier.testTag("activityItem").fillMaxSize(),
       onClick = onClick,
@@ -271,6 +278,7 @@ fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.
                                 shape =
                                     androidx.compose.foundation.shape.RoundedCornerShape(
                                         10)) // Rounded background
+                            .testTag("extraDocumentButton") // Add padding to the button
                     ) {
                       Icon(
                           imageVector = Icons.Default.MoreVert,
@@ -284,10 +292,16 @@ fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.
       }
 }
 
-// Large parts of this code was taken without shame from
+// 98% of the following code down here was taken without shame from
 // https://medium.com/@ramadan123sayed/comprehensive-guide-to-utilizing-icons-and-images-in-jetpack-compose-with-coil-7fd2686e491e
-// This is good stuff
-
+// This is really good stuff
+/**
+ * Composable function to display an image from a URL with loading and error handling.
+ *
+ * @param imageUrl The URL of the image to display.
+ * @param loadingContent A composable function to display while the image is loading.
+ * @param errorContent A composable function to display if the image fails to load.
+ */
 @Composable
 fun AdvancedImageDisplayWithEffects(
     imageUrl: String,

--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
@@ -1,9 +1,14 @@
 package com.github.se.travelpouch.ui.dashboard
 
-import androidx.compose.foundation.clickable
+import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,8 +19,11 @@ import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -29,9 +37,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
 import com.github.se.travelpouch.model.activity.Activity
 import com.github.se.travelpouch.model.activity.ActivityViewModel
 import com.github.se.travelpouch.ui.navigation.BottomNavigationMenu
@@ -40,6 +53,8 @@ import com.github.se.travelpouch.ui.navigation.Screen
 import com.github.se.travelpouch.ui.navigation.TopLevelDestinations
 import java.util.Calendar
 import java.util.GregorianCalendar
+
+private const val A4_ASPECT_RATIO = 1f / 1.414f
 
 /**
  * This function describes how the list of activities of the travel is displayed.
@@ -140,7 +155,8 @@ fun TravelActivitiesScreen(
                             onClick = {
                               activityModelView.selectActivity(listOfActivities.value[idx])
                               navigationActions.navigateTo(Screen.EDIT_ACTIVITY)
-                            })
+                            },
+                            LocalContext.current)
                       }
                     }
                   }
@@ -156,24 +172,149 @@ fun TravelActivitiesScreen(
 }
 
 /**
- * This function displays the date of an activity, its title and its location in a card.
+ * This function displays the date of an activity, its title, its location and first 2 images.
  *
  * @param activity (Activity) : the activity to display
  * @param onClick (() -> Unit) : the function to apply when we click on an activity.
  */
 @Composable
-fun ActivityItem(activity: Activity, onClick: () -> Unit = {}) {
-  val calendar = GregorianCalendar()
-  calendar.time = activity.date.toDate()
+fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.content.Context) {
+  val calendar = GregorianCalendar().apply { time = activity.date.toDate() }
+  val images =
+      listOf(
+          "https://img.yumpu.com/30185842/1/500x640/afps-attestation-de-formation-aux-premiers-secours-programme-.jpg",
+          "https://wallpapercrafter.com/desktop6/1606440-architecture-buildings-city-downtown-finance-financial.jpg",
+          "https://assets.entrepreneur.com/content/3x2/2000/20151023204134-poker-game-gambling-gamble-cards-money-chips-game.jpeg")
+  Card(
+      modifier = Modifier.testTag("activityItem").fillMaxSize(),
+      onClick = onClick,
+      elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
+      border = BorderStroke(1.dp, Color.DarkGray)) {
+        Column(modifier = Modifier.padding(8.dp)) {
+          Text(activity.title)
+          Text(activity.location.name)
+          Text(
+              "${calendar.get(Calendar.DAY_OF_MONTH)}/${calendar.get(Calendar.MONTH) + 1}/${calendar.get(Calendar.YEAR)}")
 
-  Card(modifier = Modifier.testTag("activityItem").clickable(onClick = onClick).fillMaxSize()) {
-    Text(activity.title)
-    Text(activity.location.name)
-    Text(
-        "${calendar.get(Calendar.DAY_OF_MONTH)}/${calendar.get(Calendar.MONTH) + 1}/${
-                calendar.get(
-                    Calendar.YEAR
-                )
-            }")
-  }
+          // Handling image display logic
+          if (images.isEmpty()) {
+            // No images to show, do nothing
+          } else if (images.size == 1) {
+            // Single image - crop to A4 aspect ratio
+            Box(
+                modifier =
+                    Modifier.fillMaxWidth() // Fill the width of the parent
+                        .aspectRatio(
+                            A4_ASPECT_RATIO) // Maintain A4 aspect ratio (width / height ~ 1:1.414)
+                        .background(Color.Transparent)) {
+                  AdvancedImageDisplayWithEffects(
+                      imageUrl = images[0],
+                      loadingContent = { DefaultLoadingUI() },
+                      errorContent = { DefaultErrorUI() })
+                }
+          } else if (images.size == 2) {
+            // Two images - display side by side with a vertical separator
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                  images.take(2).forEach { imageUrl ->
+                    Box(
+                        modifier =
+                            Modifier.weight(1f)
+                                .aspectRatio(
+                                    A4_ASPECT_RATIO) // Use the same A4 aspect ratio for both images
+                                .background(Color.Transparent)) {
+                          AdvancedImageDisplayWithEffects(
+                              imageUrl = imageUrl,
+                              loadingContent = { DefaultLoadingUI() },
+                              errorContent = { DefaultErrorUI() })
+                        }
+                  }
+                }
+          } else if (images.size >= 3) {
+            // Three or more images - show the first two with a button above them
+            Column(modifier = Modifier.fillMaxWidth()) {
+              Box { // Use Box to layer the images and the button
+                // Display the first two images inside a Row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                      images.take(2).forEach { imageUrl ->
+                        Box(
+                            modifier =
+                                Modifier.weight(1f) // Ensure the images take equal space
+                                    .aspectRatio(A4_ASPECT_RATIO) // Maintain A4 aspect ratio
+                                    .background(Color.Transparent)) {
+                              AdvancedImageDisplayWithEffects(
+                                  imageUrl = imageUrl,
+                                  loadingContent = { DefaultLoadingUI() },
+                                  errorContent = { DefaultErrorUI() })
+                            }
+                      }
+                    }
+
+                // More options button on top of the second image
+                IconButton(
+                    onClick = {
+                      Toast.makeText(
+                              context,
+                              "Placeholder for document view of activity",
+                              Toast.LENGTH_LONG)
+                          .show()
+                    },
+                    modifier =
+                        Modifier.align(Alignment.BottomEnd) // Position the button on the top right
+                            .background(
+                                Color.Gray,
+                                shape =
+                                    androidx.compose.foundation.shape.RoundedCornerShape(
+                                        10)) // Rounded background
+                    ) {
+                      Icon(
+                          imageVector = Icons.Default.MoreVert,
+                          contentDescription = "More options",
+                          tint = Color.White)
+                    }
+              }
+            }
+          }
+        }
+      }
+}
+
+// Large parts of this code was taken without shame from
+// https://medium.com/@ramadan123sayed/comprehensive-guide-to-utilizing-icons-and-images-in-jetpack-compose-with-coil-7fd2686e491e
+// This is good stuff
+
+@Composable
+fun AdvancedImageDisplayWithEffects(
+    imageUrl: String,
+    loadingContent: @Composable () -> Unit = { DefaultLoadingUI() },
+    errorContent: @Composable () -> Unit = { DefaultErrorUI() }
+) {
+  SubcomposeAsyncImage(
+      model = ImageRequest.Builder(LocalContext.current).data(imageUrl).crossfade(true).build(),
+      contentDescription = "Advanced Image with Effects",
+      modifier = Modifier.fillMaxWidth(),
+      contentScale = ContentScale.Fit,
+      loading = { loadingContent() },
+      error = { errorContent() })
+}
+
+@Composable
+fun DefaultLoadingUI() {
+  Box(
+      modifier = Modifier.fillMaxSize().background(Color.LightGray),
+      contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+      }
+}
+
+@Composable
+fun DefaultErrorUI() {
+  Box(
+      modifier = Modifier.fillMaxSize().background(Color.Gray),
+      contentAlignment = Alignment.Center) {
+        Text("Failed to load image", color = Color.Red)
+      }
 }

--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/TravelActivity.kt
@@ -180,7 +180,7 @@ fun TravelActivitiesScreen(
 @Composable
 fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.content.Context) {
   val calendar = GregorianCalendar().apply { time = activity.date.toDate() }
-    // we hardcode for the moment placeholder images
+  // we hardcode for the moment placeholder images
   val images =
       listOf(
           "https://img.yumpu.com/30185842/1/500x640/afps-attestation-de-formation-aux-premiers-secours-programme-.jpg",
@@ -264,7 +264,8 @@ fun ActivityItem(activity: Activity, onClick: () -> Unit = {}, context: android.
                           .show()
                     },
                     modifier =
-                        Modifier.align(Alignment.BottomEnd) // Position the button on the bottom right
+                        Modifier.align(
+                                Alignment.BottomEnd) // Position the button on the bottom right
                             .background(
                                 Color.Gray,
                                 shape =


### PR DESCRIPTION
Copied from #120

Add a visual preview for documents linked to a specific activity in the overview.

Acceptance criteria :

- UI:
1. In the dashboard / activities overview screen of a given travel, a visual preview of documents linked to an activity.
2. Max 2 previews displayed, A4 aspect ratio, if more than 2 documents are linked an extra button leading to the document manager view is shown.
3. The extra button should be squared, rounded corners, with three dots as an icon.