### PR TITLE
Improve CI time and restore apk functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,9 @@
 name: CI - Test Runner
 
-# Run the workflow when commits are pushed on main or when a PR is modified
 on:
   push:
     branches:
       - main
-
   pull_request:
     types:
       - opened
@@ -13,48 +11,85 @@ on:
       - reopened
 
 jobs:
-  ci:
-    name: CI
-    # Execute the CI on the course's runners
+  unit_tests:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
 
     steps:
-      # First step : Checkout the repository on the runner
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of Sonar analysis (if we use Sonar Later)
+          fetch-depth: 0
 
-
-      # Kernel-based Virtual Machine (KVM) is an open source virtualization technology built into Linux. Enabling it allows the Android emulator to run faster.
-      - name: Enable KVM group perms
+      - name: Enable KVM permissions
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Setup JDK
+      - name: Setup JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "17"
 
-      # Caching is a very useful part of a CI, as a workflow is executed in a clean environment every time,
-      # this means that one would need to re-download and re-process gradle files for every run. Which is very time consuming.
-      #
-      # To avoid that, we cache the the gradle folder to reuse it later.
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
 
-        # Load google-services.json and local.properties from the secrets
-      - name: Decode secrets
+      - name: Decode secrets for Google services
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-          # LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-      #   echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+
+      - name: Set execute permissions for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Run Unit Tests
+        run: ./gradlew check --parallel --build-cache
+
+      - name: Save Unit Test Results
+        if: success()  # Only save if the tests were successful
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-test-results
+          path: |
+            app/build/test-results/
+            app/build/reports/
+            app/build/outputs/
+
+  ui_tests:
+    name: Run UI Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Enable KVM permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Decode secrets for Google services
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+        run: |
+          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
 
       # Cache the Emulator, if the cache does not hit, create the emulator
       - name: AVD cache
@@ -75,41 +110,17 @@ jobs:
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
+          disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
-      - name: Grant execute permission for gradlew
-        run: |
-          chmod +x ./gradlew
-
-      # Check formatting
-      - name: KTFmt Check
-        run: |
-          ./gradlew ktfmtCheck
+      - name: Set execute permissions for gradlew
+        run: chmod +x ./gradlew
 
       # This step runs gradle commands to build the application
       - name: Assemble
         run: |
           # To run the CI with debug information, add --info
           ./gradlew assemble lint --parallel --build-cache
-
-      - name: Cache firebase emulators
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/firebase/emulators
-          key: ${{ runner.os }}-firebase-emulators-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-firebase-emulators-
-
-      - name : Install Firebase CLI
-        run: |
-          curl -sL https://firebase.tools | bash
-
-      # Run Unit tests
-      - name: Run tests
-        run: |
-          # To run the CI with debug information, add --info
-          ./gradlew check --parallel --build-cache
 
       # Run connected tests on the emulator
       - name: run tests
@@ -121,15 +132,85 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: firebase emulators:exec "./gradlew connectedCheck --parallel --build-cache"
+          script: ./gradlew connectedCheck --parallel --build-cache
 
-      # This step generates the coverage report which will be uploaded to sonar
-      - name: Generate Coverage Report
+      - name: Save UI Test Results
+        if: success()  # Only save if the tests were successful
+        uses: actions/upload-artifact@v3
+        with:
+          name: ui-test-results
+          path: |
+            app/build/androidTests/connected/
+            app/build/reports/
+            app/build/outputs/
+            app/build/test-results/
+
+  coverage:
+    name: Generate and Upload Coverage Report
+    runs-on: ubuntu-latest
+    needs: [unit_tests, ui_tests]  # Ensure both test jobs complete first
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Download Unit Test Results
+        uses: actions/download-artifact@v3
+        with:
+          name: unit-test-results
+          path: unit-test-results/
+
+      - name: Download UI Test Results
+        uses: actions/download-artifact@v3
+        with:
+          name: ui-test-results
+          path: ui-test-results/
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          java-package: jdk
+
+      - name: Decode secrets for Google services
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
         run: |
-          ./gradlew jacocoTestReport
+          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+      - name: Copy downloaded unit test results to build folder
+        run: |
+          echo "Listing downloaded unit-test-results:"
+          ls -R unit-test-results/
+          
+          echo "Copying unit-test-results to ./app/build..."
+          cp -r unit-test-results/. ./app/build/ || true  # Overwrite if needed, create directories as necessary
 
-      # Upload the various reports to sonar
-      - name: Upload report to SonarCloud
+      - name: Copy downloaded UI test results to build folder
+        run: |
+          echo "Listing downloaded ui-test-results:"
+          ls -R ui-test-results/
+          
+          echo "Copying ui-test-results to ./app/build..."
+          cp -r ui-test-results/. ./app/build/ || true  # Overwrite if needed, create directories as necessary
+
+      - name: List contents of ./app/build folder after copying
+        run: |
+          echo "Listing contents of ./app/build after copying:"
+          ls -R ./app/build/  # Ensure everything is copied correctly
+
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+
+      - name: Generate Jacoco Coverage Report
+        run: ./gradlew jacocoTestReport
+
+      - name: Upload Coverage to SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,7 +73,7 @@ android {
     }
 
     testCoverage {
-        jacocoVersion = "0.8.8"
+        jacocoVersion = "0.8.12"
     }
 
     buildFeatures {
@@ -298,6 +298,15 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
+    // strange workaround to fix the 65535 issue
+    // https://github.com/EPFLSWENT2024G1/partagix/pull/78 taken from this PR of a previous year
+    doLast {
+        val reportFile = reports.xml.outputLocation.asFile.get()
+        val newContent = reportFile.readText().replace("<line[^>]+nr=\"65535\"[^>]*>".toRegex(), "")
+        reportFile.writeText(newContent)
+
+        logger.quiet("Wrote summarized jacoco test coverage report xml to $reportFile.absolutePath}")
+    }
 }
 
 tasks.register("beforeCommitCheck") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,7 @@ android {
     val keyAlias = System.getenv("KEY_ALIAS") ?: localProperties.getProperty("KEY_ALIAS")
     val keyPassword = System.getenv("KEY_PASSWORD") ?: localProperties.getProperty("KEY_PASSWORD")
     val mapsApiKey: String = System.getenv("MAPS_API_KEY") ?: (localProperties.getProperty("MAPS_API_KEY") ?: "")
+    var chosenConfig: Boolean = false // this is to avoid issues with the signing config when building apk
 
     defaultConfig {
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
@@ -45,15 +46,16 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
-            isShrinkResources = true
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
+            //isMinifyEnabled = true
+            //isShrinkResources = true
+            //proguardFiles(
+            //    getDefaultProguardFile("proguard-android-optimize.txt"),
+            //    "proguard-rules.pro"
+            //)
             // Only assign signing config if it exists
             if (keystoreFile != null && keystorePassword != null && keyAlias != null && keyPassword != null) {
                 println("creating a release config")
+                chosenConfig = true // prevent debug signingConfig from getting created
                 signingConfig = signingConfigs.create("release") {
                     storeFile(file(keystoreFile))
                     storePassword(keystorePassword)
@@ -67,6 +69,18 @@ android {
         }
 
         debug {
+            if (keystoreFile != null && keystorePassword != null && keyAlias != null && keyPassword != null && !chosenConfig) {
+                println("creating a debug config")
+                signingConfig = signingConfigs.create("debug") {
+                    storeFile(file(keystoreFile))
+                    storePassword(keystorePassword)
+                    keyAlias(keyAlias)
+                    keyPassword(keyPassword)
+                }
+            }
+            else {
+                println("No debug signing config set.")
+            }
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
         }


### PR DESCRIPTION
Description:
The CI is becoming quite long while some parts are able to be run side by side instead of sequentially.
In addition, the APK generated sometimes doesn't work as intended because R8 when minifying removes some vital libraries.
To make the APK useable again we need to remove the optimizations added by R8 to ensure complete functionality

Acceptance Criteria:
- Decrease runtime of the pipeline if possible
- APK should be fully functional