### PR TITLE
Fix: text fields are not visible on edit and participant list

### DIFF
--- a/app/src/main/java/com/github/se/travelpouch/ui/travel/EditTravelSettings.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/travel/EditTravelSettings.kt
@@ -172,13 +172,17 @@ fun EditTravelSettingsScreen(
             OutlinedTextField(
                 value = titleText.value,
                 onValueChange = { keystroke -> titleText.value = keystroke },
-                modifier = Modifier.testTag("inputTravelTitle"),
+                modifier =
+                    Modifier.testTag("inputTravelTitle").fillMaxWidth().padding(horizontal = 10.dp),
                 label = { Text("Title") },
                 placeholder = { Text("Name the Travel") })
             OutlinedTextField(
                 value = descriptionText.value,
                 onValueChange = { keystroke -> descriptionText.value = keystroke },
-                modifier = Modifier.testTag("inputTravelDescription"),
+                modifier =
+                    Modifier.testTag("inputTravelDescription")
+                        .fillMaxWidth()
+                        .padding(horizontal = 10.dp),
                 label = { Text("Description") },
                 placeholder = { Text("Describe the Travel") })
 
@@ -187,7 +191,10 @@ fun EditTravelSettingsScreen(
                 onValueChange = { locationName.value = it },
                 label = { Text("Location Name") },
                 placeholder = { Text("Enter location name") },
-                modifier = Modifier.testTag("inputTravelLocationName"))
+                modifier =
+                    Modifier.testTag("inputTravelLocationName")
+                        .fillMaxWidth()
+                        .padding(horizontal = 10.dp))
 
             // Latitude Input
             OutlinedTextField(
@@ -195,7 +202,10 @@ fun EditTravelSettingsScreen(
                 onValueChange = { latitude.value = it },
                 label = { Text("Latitude") },
                 placeholder = { Text("Enter latitude (e.g. 48.8566)") },
-                modifier = Modifier.testTag("inputTravelLatitude"))
+                modifier =
+                    Modifier.testTag("inputTravelLatitude")
+                        .fillMaxWidth()
+                        .padding(horizontal = 10.dp))
 
             // Longitude Input
             OutlinedTextField(
@@ -203,13 +213,19 @@ fun EditTravelSettingsScreen(
                 onValueChange = { longitude.value = it },
                 label = { Text("Longitude") },
                 placeholder = { Text("Enter longitude (e.g. 2.3522)") },
-                modifier = Modifier.testTag("inputTravelLongitude"))
+                modifier =
+                    Modifier.testTag("inputTravelLongitude")
+                        .fillMaxWidth()
+                        .padding(horizontal = 10.dp))
             OutlinedTextField(
                 value = startTime.value,
                 onValueChange = { keystroke -> startTime.value = keystroke }, // Allow manual input
                 label = { Text("Start Date") },
                 placeholder = { Text("DD/MM/YYYY") },
-                modifier = Modifier.fillMaxWidth().testTag("inputTravelStartTime"),
+                modifier =
+                    Modifier.testTag("inputTravelStartTime")
+                        .fillMaxWidth()
+                        .padding(horizontal = 10.dp),
                 trailingIcon = {
                   IconButton(
                       onClick = {
@@ -230,7 +246,10 @@ fun EditTravelSettingsScreen(
                 }, // Allow manual input
                 label = { Text("End Date") },
                 placeholder = { Text("DD/MM/YYYY") },
-                modifier = Modifier.fillMaxWidth().testTag("inputTravelEndTime"),
+                modifier =
+                    Modifier.testTag("inputTravelEndTime")
+                        .fillMaxWidth()
+                        .padding(horizontal = 10.dp),
                 trailingIcon = {
                   IconButton(
                       onClick = {

--- a/app/src/main/java/com/github/se/travelpouch/ui/travel/ParticipantRow.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/travel/ParticipantRow.kt
@@ -1,5 +1,6 @@
 package com.github.se.travelpouch.ui.travel
 
+import TruncatedText
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -38,14 +39,16 @@ fun ParticipantRow(
         Text(
             text = participant.value.name,
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(10.dp).testTag("participantName"))
-        Text(
+            modifier = Modifier.padding(10.dp).testTag("participantName").weight(0.5f))
+        TruncatedText(
             text = participant.value.email,
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(10.dp).testTag("participantEmail"))
-        Text(
+            maxLength = 30,
+            modifier = Modifier.padding(10.dp).testTag("participantEmail").weight(0.8f))
+        TruncatedText(
             text = selectedTravel.allParticipants[Participant(participant.key)]!!.name,
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(10.dp).testTag("participantRole"))
+            maxLength = 20,
+            modifier = Modifier.padding(10.dp).testTag("participantRole").weight(1f))
       }
 }


### PR DESCRIPTION
Taken from #175

Description: Some text fields are not displayed or displayed too badly because of formatting issues on smaller and medium sized devices. Thus we need the UI to atleast reduce the effect of this.

Acceptance criteria: - All text fields must be displayed in participant list and edit travel text fields need to be of the same size.