### PR TITLE
feat: Thumbnailling - frontend implementation

### DIFF
--- a/app/src/main/java/com/github/se/travelpouch/model/documents/DocumentRepository.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/documents/DocumentRepository.kt
@@ -11,6 +11,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.functions.FirebaseFunctions
 import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.StorageException
 
 /** Interface for the DocumentRepository. */
 interface DocumentRepository {
@@ -24,6 +25,14 @@ interface DocumentRepository {
       document: DocumentContainer,
       onSuccess: (String) -> Unit,
       onFailure: (Exception) -> Unit
+  )
+
+  fun getThumbnailUrl(
+    document: DocumentContainer,
+    width: Int,
+    onSuccess: (String) -> Unit,
+    onFailure: (Exception) -> Unit,
+    canFail: Boolean = true
   )
 
   fun uploadDocument(
@@ -121,6 +130,61 @@ class DocumentRepositoryFirestore(
         .downloadUrl
         .addOnSuccessListener { uri -> onSuccess(uri.toString()) }
         .addOnFailureListener(onFailure)
+  }
+
+  private fun generateThumbnail(
+    document: DocumentContainer,
+    width: Int,
+    onSuccess: () -> Unit,
+    onFailure: (Exception) -> Unit
+  ) {
+    functions
+      .getHttpsCallable("generateThumbnailCall")
+      .call(
+        mapOf(
+          "travelId" to document.travelRef.id,
+          "documentId" to document.ref.id,
+          "width" to width))
+      .continueWith { task ->
+        if (task.isSuccessful) {
+          onSuccess()
+        } else {
+          Log.e("DocumentRepositoryFirestore", "Error generating thumbnail for document id=${document.ref.id},width=$width", task.exception)
+          onFailure(task.exception!!)
+        }
+      }
+  }
+
+  /**
+   * Try to get the thumbnailUrl a document from the Firestore database.
+   *
+   * @param document The document to fetch the download URL for.
+   * @param width The width of the thumbnail.
+   * @param onSuccess Callback function to be called when the download URL is fetched successfully.
+   * @param onFailure Callback function to be called when an error occurs.
+   */
+  override fun getThumbnailUrl(
+    document: DocumentContainer,
+    width: Int,
+    onSuccess: (String) -> Unit,
+    onFailure: (Exception) -> Unit,
+    canFail: Boolean
+    ) {
+    storage
+      .getReference("${document.ref.id}-thumb-$width")
+      .downloadUrl
+      .addOnSuccessListener { uri -> onSuccess(uri.toString()) }
+      .addOnFailureListener { err ->
+        if (canFail && err is StorageException && err.errorCode == StorageException.ERROR_OBJECT_NOT_FOUND) {
+          Log.d("DocumentRepositoryFirestore", "Thumbnail for document id=${document.ref.id},width=$width not found, generating one...", err)
+          generateThumbnail(document, width, {
+            getThumbnailUrl(document, width, onSuccess, onFailure, false)
+          }, onFailure)
+        } else {
+          Log.e("DocumentRepositoryFirestore", "Error getting thumbnail for document id=${document.ref.id},width=$width", err)
+          onFailure(err)
+        }
+      }
   }
 
   override fun uploadDocument(

--- a/app/src/main/java/com/github/se/travelpouch/model/documents/DocumentViewModel.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/documents/DocumentViewModel.kt
@@ -35,6 +35,9 @@ open class DocumentViewModel(
   private val _downloadUrls = mutableStateMapOf<String, String>()
   val downloadUrls: Map<String, String>
     get() = _downloadUrls
+  private val _thumbnailUrls = mutableStateMapOf<String, String>()
+  val thumbnailUrls: Map<String, String>
+    get() = _thumbnailUrls
 
   fun setIdTravel(travelId: String) {
     repository.setIdTravel({ getDocuments() }, travelId)
@@ -64,7 +67,6 @@ open class DocumentViewModel(
    * Downloads a Document from Firebase store adn store it in the folder pointed by documentFile
    *
    * @param documentFile The folder in which to create the file
-   * @param contentResolver A content resolver to
    */
   fun storeSelectedDocument(documentFile: DocumentFile) {
     val mimeType = selectedDocument.value?.fileFormat?.mimeType
@@ -78,17 +80,6 @@ open class DocumentViewModel(
 
     fileDownloader.downloadFile(mimeType, title, ref, documentFile)
   }
-
-  //    /**
-  //     * Updates a Document.
-  //     *
-  //     * @param document The Document to be updated.
-  //     */
-  //    fun updateDocument(document: DocumentContainer) {
-  //        repository.updateDocument(document,
-  //            onSuccess = { getDocuments() },
-  //            onFailure = { Log.e("DocumentsViewModel", "Failed to update Document", it) })
-  //    }
 
   /**
    * Deletes a Document by its ID.
@@ -114,7 +105,18 @@ open class DocumentViewModel(
     repository.getDownloadUrl(
         document,
         onSuccess = { _downloadUrls[document.ref.id] = it },
-        onFailure = { Log.e("DocumentPreview", "Failed to get image uri", it) })
+        onFailure = { Log.e("DocumentsViewModel", "Failed to get thumbnail uri", it) })
+  }
+
+  fun getDocumentThumbnail(document: DocumentContainer, width: Int = 300) {
+    if (_thumbnailUrls.containsKey("${document.ref.id}-thumb-$width")) {
+      return
+    }
+    repository.getThumbnailUrl(
+        document,
+        width,
+        onSuccess = { _thumbnailUrls["${document.ref.id}-thumb-$width"] = it },
+        onFailure = { Log.e("DocumentsViewModel", "Failed to get thumbnail uri", it) })
   }
 
   fun uploadDocument(travelId: String, bytes: ByteArray, format: DocumentFileFormat) {

--- a/app/src/main/java/com/github/se/travelpouch/ui/documents/DocumentListItem.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/documents/DocumentListItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -37,6 +38,8 @@ import com.rizzi.bouquet.rememberVerticalPdfReaderState
 import java.text.SimpleDateFormat
 import java.util.Locale
 
+const val THUMBNAIL_WIDTH = 150
+
 /**
  * Composable function for displaying a document item.
  *
@@ -48,9 +51,9 @@ fun DocumentListItem(
     documentViewModel: DocumentViewModel,
     onClick: () -> Unit
 ) {
-  var previewUri by remember { mutableStateOf("") }
-  LaunchedEffect(documentContainer) { documentViewModel.getDownloadUrl(documentContainer) }
-  previewUri = documentViewModel.downloadUrls[documentContainer.ref.id] ?: ""
+  var thumbnailUri by remember { mutableStateOf("") }
+  LaunchedEffect(documentContainer) { documentViewModel.getDocumentThumbnail(documentContainer, THUMBNAIL_WIDTH) }
+  thumbnailUri = documentViewModel.thumbnailUrls["${documentContainer.ref.id}-thumb-$THUMBNAIL_WIDTH"] ?: ""
 
   Card(
       modifier =
@@ -81,10 +84,19 @@ fun DocumentListItem(
               }
 
           Box(modifier = Modifier.height(200.dp).width(150.dp)) {
-            if (previewUri.isNotEmpty()) {
-              DocumentPreviewBox(previewUri, documentContainer.fileFormat)
+            if (thumbnailUri.isNotEmpty()) {
+              AsyncImage(
+                model = thumbnailUri,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize(),
+              )
             } else {
-              // Display a placeholder
+              CircularProgressIndicator(
+                modifier =
+                Modifier.align(Alignment.Center).testTag("loadingSpinner"),
+                color = MaterialTheme.colorScheme.primary,
+                strokeWidth = 5.dp)
             }
           }
 
@@ -93,23 +105,5 @@ fun DocumentListItem(
               style = MaterialTheme.typography.bodyMedium,
               modifier = Modifier.testTag("DocumentTitle"))
         }
-  }
-}
-
-@Composable
-fun DocumentPreviewBox(previewUri: String, fileFormat: DocumentFileFormat) {
-  if (fileFormat == DocumentFileFormat.PDF) {
-    val pdfState =
-        rememberVerticalPdfReaderState(
-            resource = ResourceType.Remote(previewUri), isZoomEnable = false)
-    VerticalPDFReader(
-        state = pdfState, modifier = Modifier.fillMaxSize().background(color = Color.Gray))
-  } else {
-    AsyncImage(
-        model = previewUri,
-        contentDescription = null,
-        contentScale = ContentScale.Fit,
-        modifier = Modifier.fillMaxSize(),
-    )
   }
 }

--- a/app/src/main/java/com/github/se/travelpouch/ui/documents/DocumentPreview.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/documents/DocumentPreview.kt
@@ -96,7 +96,7 @@ fun DocumentPreview(documentViewModel: DocumentViewModel, navigationActions: Nav
       Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.inversePrimary)) {
         Column(modifier = Modifier.fillMaxWidth()) {
           Text(
-              text = documentContainer.title,
+              text = "Document ID: ${documentContainer.ref.id}",
               style = MaterialTheme.typography.bodyLarge,
               modifier = Modifier.padding(8.dp).testTag("documentTitle"))
 


### PR DESCRIPTION
Use the new Cloud Function implemented by #155 to load thumbnails in the DocumentList instead of full previews.

How this works:
- DocumentListItem try to load the thumbnail at the expected path through the ViewModel
  - If it exists, the job is done and the URL will be available to the AsyncImage
- If the ViewModel doesn't find the thumbnail it uses the Cloud Function to generate a new one for the given size
- If it succeeds, the ViewModel retries to get the downloadUrl of the thumbnail
- Finally the URL is made available for the AsyncImage