### PR TITLE
hotfix: Get user's travel using allParticipants instead of listParticipant

### DIFF
--- a/app/src/main/java/com/github/se/travelpouch/model/travels/ListTravelViewModel.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/travels/ListTravelViewModel.kt
@@ -237,13 +237,7 @@ open class ListTravelViewModel @Inject constructor(private val repository: Trave
           val newParticipantMap = selectedTravel.allParticipants.toMutableMap()
           newParticipantMap[newParticipant] = Role.PARTICIPANT
 
-          val newParticipantList = selectedTravel.listParticipant.toMutableList()
-          newParticipantList.plus(user.fsUid)
-
-          val newTravel =
-              selectedTravel.copy(
-                  allParticipants = newParticipantMap.toMap(),
-                  listParticipant = newParticipantList.toList())
+          val newTravel = selectedTravel.copy(allParticipants = newParticipantMap.toMap())
           updateTravel(newTravel)
           onSuccess(newTravel)
         },

--- a/app/src/main/java/com/github/se/travelpouch/model/travels/TravelRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/travels/TravelRepositoryFirestore.kt
@@ -175,22 +175,20 @@ class TravelRepositoryFirestore(private val db: FirebaseFirestore) : TravelRepos
   ) {
 
     Log.d("TravelRepositoryFirestore", "getTravels")
-    db.collection(collectionPath)
-        .whereArrayContains("listParticipant", currentUserUid)
-        .get()
-        .addOnCompleteListener { task ->
-          if (task.isSuccessful) {
-            val travels =
-                task.result?.documents?.mapNotNull { document -> documentToTravel(document) }
-                    ?: emptyList()
-            onSuccess(travels)
-          } else {
-            task.exception?.let { e ->
-              Log.e("TravelRepositoryFirestore", "Error getting documents", e)
-              onFailure(e)
-            }
-          }
+    db.collection(collectionPath).get().addOnCompleteListener { task ->
+      if (task.isSuccessful) {
+        val travels =
+            task.result?.documents?.mapNotNull { document -> documentToTravel(document) }
+                ?: emptyList()
+        val participant = Participant(currentUserUid)
+        onSuccess(travels.filter { it.allParticipants.containsKey(participant) })
+      } else {
+        task.exception?.let { e ->
+          Log.e("TravelRepositoryFirestore", "Error getting documents", e)
+          onFailure(e)
         }
+      }
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/se/travelpouch/ui/travel/EditTravelSettings.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/travel/EditTravelSettings.kt
@@ -342,7 +342,7 @@ fun EditTravelSettingsScreen(
           modifier = Modifier.padding(padding).testTag("noTravelSelectedText"))
     }
     if (expandedAddUserDialog) {
-      val addUserEmail = remember { mutableStateOf("newuser.email@example.org") }
+      val addUserEmail = remember { mutableStateOf("") }
       Dialog(onDismissRequest = { setExpandedAddUserDialog(false) }) {
         Box(Modifier.size(800.dp, 250.dp).background(Color.White).testTag("addUserDialogBox")) {
           Column(


### PR DESCRIPTION
The list of the travels was filtered using the listParticipant list, but the refactoring of last week deprecated this list to use the map allParticipants instead.