### PR TITLE
feat: add GPSRepository for handling location updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -192,6 +192,7 @@ dependencies {
     implementation(libs.firebase.functions.ktx)
     implementation(libs.androidx.runtime.livedata)
     implementation(libs.androidx.navigation.testing)
+    implementation(libs.play.services.location)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)

--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/authentication/SignInViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/authentication/SignInViewTest.kt
@@ -1,7 +1,5 @@
 package com.github.se.travelpouch.ui.authentication
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -74,18 +72,6 @@ class SignInViewTest {
           auth = mockFirebaseAuth)
     }
     composeTestRule.onNodeWithTag("loginButtonRow").performClick()
-  }
-
-  @Test
-  fun signInScreenTestSpinner() {
-    val yesSpin: MutableState<Boolean> = mutableStateOf(true)
-    composeTestRule.setContent {
-      SignInScreen(
-          navigationActions = mockNavigationActions, profileModelView, travelViewModel, yesSpin)
-    }
-    composeTestRule.waitForIdle()
-    composeTestRule.onNodeWithTag("loadingSpinner", useUnmergedTree = true).assertExists()
-    composeTestRule.onNodeWithTag("loadingSpinner").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/authentication/SignInViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/authentication/SignInViewTest.kt
@@ -84,7 +84,7 @@ class SignInViewTest {
           navigationActions = mockNavigationActions, profileModelView, travelViewModel, yesSpin)
     }
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(2000) { yesSpin.value }
+    composeTestRule.onNodeWithTag("loadingSpinner", useUnmergedTree = true).assertExists()
     composeTestRule.onNodeWithTag("loadingSpinner").assertIsDisplayed()
   }
 

--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/authentication/SignInViewTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/authentication/SignInViewTest.kt
@@ -84,6 +84,7 @@ class SignInViewTest {
           navigationActions = mockNavigationActions, profileModelView, travelViewModel, yesSpin)
     }
     composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(2000) { yesSpin.value }
     composeTestRule.onNodeWithTag("loadingSpinner").assertIsDisplayed()
   }
 

--- a/app/src/main/java/com/github/se/travelpouch/model/gps/GPSRepository.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/gps/GPSRepository.kt
@@ -7,6 +7,7 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.Priority
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -15,7 +16,7 @@ import kotlinx.coroutines.flow.map
 
 /**
  * Repository for handling GPS location updates. This class provides a Flow for listening to
- * continuous GPS location updates and a Task for fetching the current location.
+ * continuous GPS location updates and a possibility to request a single location update.
  *
  * @param fusedLocationClient The FusedLocationProviderClient instance to use for location updates.
  */
@@ -34,7 +35,7 @@ class GPSRepository(private val fusedLocationClient: FusedLocationProviderClient
   @SuppressLint("MissingPermission") // Ensure permissions are handled elsewhere
   fun getGPSUpdates(): Flow<Location?> = callbackFlow {
     val locationRequest =
-        LocationRequest.Builder(LocationRequest.PRIORITY_HIGH_ACCURACY, LOCATION_UPDATE_INTERVAL)
+        LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, LOCATION_UPDATE_INTERVAL)
             .setMinUpdateIntervalMillis(LOCATION_FASTEST_INTERVAL)
             .setWaitForAccurateLocation(true) // Ensures more precise location updates
             .build()

--- a/app/src/main/java/com/github/se/travelpouch/model/gps/GPSRepository.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/gps/GPSRepository.kt
@@ -1,0 +1,107 @@
+package com.github.se.travelpouch.model.gps
+
+import android.annotation.SuppressLint
+import android.location.Location
+import android.util.Log
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Repository for handling GPS location updates. This class provides a Flow for listening to
+ * continuous GPS location updates and a Task for fetching the current location.
+ *
+ * @param fusedLocationClient The FusedLocationProviderClient instance to use for location updates.
+ */
+class GPSRepository(private val fusedLocationClient: FusedLocationProviderClient) {
+
+  companion object {
+    private const val LOCATION_UPDATE_INTERVAL = 10000L // 10 seconds
+    private const val LOCATION_FASTEST_INTERVAL = 2000L // 2 seconds
+    private const val TAG = "GPSRepository"
+  }
+
+  /**
+   * Provides a Flow for listening to continuous GPS location updates. Consumers of this Flow will
+   * receive the latest location data.
+   */
+  @SuppressLint("MissingPermission") // Ensure permissions are handled elsewhere
+  fun getGPSUpdates(): Flow<Location?> = callbackFlow {
+    val locationRequest =
+        LocationRequest.Builder(LocationRequest.PRIORITY_HIGH_ACCURACY, LOCATION_UPDATE_INTERVAL)
+            .setMinUpdateIntervalMillis(LOCATION_FASTEST_INTERVAL)
+            .setWaitForAccurateLocation(true) // Ensures more precise location updates
+            .build()
+
+    val locationCallback =
+        object : LocationCallback() {
+          override fun onLocationResult(locationResult: LocationResult) {
+            locationResult.locations.forEach { location -> trySend(location) }
+          }
+        }
+
+    // Start location updates
+    fusedLocationClient
+        .requestLocationUpdates(locationRequest, locationCallback, null)
+        .addOnFailureListener { exception ->
+          Log.e(TAG, "Failed to request location updates", exception)
+          close(exception)
+        }
+
+    // Stop location updates when Flow is closed
+    awaitClose {
+      fusedLocationClient.removeLocationUpdates(locationCallback)
+      Log.d(TAG, "Location updates stopped")
+    }
+  }
+
+  /** Provides a Flow for GPS updates directly formatted as LatLng for map usage. */
+  @SuppressLint("MissingPermission") // Ensure permissions are handled elsewhere
+  fun getGPSUpdatesForMap(): Flow<LatLng?> =
+      getGPSUpdates().map { location -> location?.let { LatLng(it.latitude, it.longitude) } }
+
+  /**
+   * Requests a single location update and provides the location data to the onSuccess callback.
+   *
+   * @param onSuccess Callback that is called when the location is successfully fetched.
+   * @param onFailure Callback that is called when the location request fails.
+   */
+  @SuppressLint("MissingPermission")
+  fun getCurrentLocation(onSuccess: (Location) -> Unit, onFailure: (Exception) -> Unit) {
+    val locationRequest =
+        LocationRequest.Builder(
+                LocationRequest.PRIORITY_HIGH_ACCURACY, 0 // Single request
+                )
+            .setWaitForAccurateLocation(true)
+            .build()
+
+    val locationCallback =
+        object : LocationCallback() {
+          override fun onLocationResult(locationResult: LocationResult) {
+            val location = locationResult.lastLocation
+            if (location != null) {
+
+              onSuccess(location) // Notify success
+            } else {
+
+              onFailure(Exception("Location is null")) // Handle edge case
+            }
+            fusedLocationClient.removeLocationUpdates(this)
+          }
+        }
+
+    fusedLocationClient
+        .requestLocationUpdates(locationRequest, locationCallback, null)
+        .addOnFailureListener { ex ->
+          Log.e("GPSRepository", "Failed to request single location update", ex)
+          onFailure(ex) // Notify failure
+          fusedLocationClient.removeLocationUpdates(locationCallback)
+        }
+  }
+}

--- a/app/src/main/java/com/github/se/travelpouch/model/gps/GPSViewModel.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/gps/GPSViewModel.kt
@@ -1,0 +1,70 @@
+package com.github.se.travelpouch.model.gps
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+
+class GPSViewModel(private val gpsRepository: GPSRepository) : ViewModel() {
+
+  // Holds the real-time continuous location updates as a StateFlow
+  private val _realTimeLocation = MutableStateFlow<LatLng?>(null)
+  val realTimeLocation: StateFlow<LatLng?>
+    get() = _realTimeLocation
+
+  // Holds the single location update as a StateFlow
+  private val _singleLocationUpdate = MutableStateFlow<LatLng?>(null)
+  val singleLocationUpdate: StateFlow<LatLng?>
+    get() = _singleLocationUpdate
+
+  fun startRealTimeLocationUpdates() {
+    Log.d("GPSViewModel", "startRealTimeLocationUpdates")
+
+    viewModelScope.launch {
+      gpsRepository
+          .getGPSUpdatesForMap()
+          .catch {
+            _realTimeLocation.value = null // Reset the StateFlow
+          }
+          .collect { location ->
+            Log.d("GPSViewModel", "Location: $location")
+            _realTimeLocation.value = location
+          }
+    }
+  }
+
+  /** Fetch the current location (real-time only) and update the StateFlow. */
+  fun fetchCurrentLocation() {
+
+    viewModelScope.launch {
+      gpsRepository.getCurrentLocation(
+          onSuccess = { location ->
+            _singleLocationUpdate.value = LatLng(location.latitude, location.longitude)
+          },
+          onFailure = { _singleLocationUpdate.value = null })
+    }
+  }
+
+  /** Factory for creating GPSViewModel instances. */
+  companion object {
+    fun Factory(context: Context): ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(GPSViewModel::class.java)) {
+              val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
+              val gpsRepository = GPSRepository(fusedLocationClient)
+              return GPSViewModel(gpsRepository) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+          }
+        }
+  }
+}

--- a/app/src/main/java/com/github/se/travelpouch/model/gps/GPSViewModel.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/gps/GPSViewModel.kt
@@ -12,6 +12,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
+/**
+ * ViewModel for the GPS feature.
+ *
+ * @param gpsRepository Repository for the GPS feature.
+ * @constructor Creates a GPSViewModel.
+ */
 class GPSViewModel(private val gpsRepository: GPSRepository) : ViewModel() {
 
   // Holds the real-time continuous location updates as a StateFlow
@@ -24,6 +30,7 @@ class GPSViewModel(private val gpsRepository: GPSRepository) : ViewModel() {
   val singleLocationUpdate: StateFlow<LatLng?>
     get() = _singleLocationUpdate
 
+  /** Start the real-time location updates and update the StateFlow. */
   fun startRealTimeLocationUpdates() {
     Log.d("GPSViewModel", "startRealTimeLocationUpdates")
 

--- a/app/src/test/java/com/github/se/travelpouch/model/gps/GPSRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/travelpouch/model/gps/GPSRepositoryTest.kt
@@ -1,0 +1,161 @@
+package com.github.se.travelpouch.model.gps
+
+import android.location.Location
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.tasks.Tasks
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GPSRepositoryUnitTest {
+
+  private lateinit var fusedLocationClient: FusedLocationProviderClient
+  private lateinit var repository: GPSRepository
+
+  @Before
+  fun setUp() {
+    // Mock the FusedLocationProviderClient
+    fusedLocationClient = mock(FusedLocationProviderClient::class.java)
+
+    // Instantiate the GPSRepository
+    repository = GPSRepository(fusedLocationClient)
+  }
+
+  @Test
+  fun testGetGPSUpdatesEmitsLocationUpdates() = runBlocking {
+    // Simulate a location
+    val mockLocation =
+        mock(Location::class.java).apply {
+          `when`(latitude).thenReturn(48.8566)
+          `when`(longitude).thenReturn(2.3522)
+        }
+    val locationResult = LocationResult.create(listOf(mockLocation))
+
+    // Simulate the behavior of fusedLocationClient
+    doAnswer { invocation ->
+          val callback = invocation.arguments[1] as LocationCallback
+          // Call onLocationResult with the simulated result
+          callback.onLocationResult(locationResult)
+
+          // Return a successful Task<Void>
+          Tasks.forResult(null)
+        }
+        .`when`(fusedLocationClient)
+        .requestLocationUpdates(
+            any(LocationRequest::class.java), any(LocationCallback::class.java), any())
+
+    // Collect the first emitted location
+    val emittedLocation = repository.getGPSUpdates().first()
+
+    // Verify the results
+    assertEquals(48.8566, emittedLocation?.latitude)
+    assertEquals(2.3522, emittedLocation?.longitude)
+  }
+
+  @Test
+  fun testGetGPSUpdatesHandlesErrors() = runBlocking {
+    // Simulate a location to verify the callback is called correctly
+    val mockLocation =
+        mock(Location::class.java).apply {
+          `when`(latitude).thenReturn(48.8566)
+          `when`(longitude).thenReturn(2.3522)
+        }
+    val locationResult = LocationResult.create(listOf(mockLocation))
+
+    // Configure fusedLocationClient to return a failed Task
+    doAnswer { invocation ->
+          val callback = invocation.arguments[1] as LocationCallback
+          // Call onLocationResult to simulate a location
+          callback.onLocationResult(locationResult)
+
+          // Throw a simulated exception after emitting a location
+          throw Exception("Permission denied")
+        }
+        .`when`(fusedLocationClient)
+        .requestLocationUpdates(
+            any(LocationRequest::class.java), any(LocationCallback::class.java), any())
+
+    // Collect data and handle exceptions
+    var caughtException: Exception? = null
+
+    try {
+      repository.getGPSUpdates().first() // This should throw an exception
+    } catch (e: Exception) {
+      caughtException = e
+    }
+
+    // Verify that an exception was thrown
+    assertTrue(caughtException is Exception)
+    assertEquals("Permission denied", caughtException?.message)
+  }
+
+  @Test
+  fun testGetGPSUpdatesForMapEmitsLatLng() = runBlocking {
+    val mockLocation =
+        mock(Location::class.java).apply {
+          `when`(latitude).thenReturn(48.8566)
+          `when`(longitude).thenReturn(2.3522)
+        }
+    val locationResult = LocationResult.create(listOf(mockLocation))
+
+    doAnswer { invocation ->
+          val callback = invocation.arguments[1] as LocationCallback
+          callback.onLocationResult(locationResult)
+          Tasks.forResult(null)
+        }
+        .`when`(fusedLocationClient)
+        .requestLocationUpdates(
+            any(LocationRequest::class.java), any(LocationCallback::class.java), any())
+
+    val emittedLatLng = repository.getGPSUpdatesForMap().first()
+
+    assertNotNull(emittedLatLng)
+    assertNotNull(emittedLatLng?.latitude)
+    assertNotNull(emittedLatLng?.longitude)
+
+    assertEquals(48.8566, emittedLatLng!!.latitude, 0.0001)
+    assertEquals(2.3522, emittedLatLng.longitude, 0.0001)
+  }
+
+  @Test
+  fun testGetCurrentLocationSuccess() {
+    val mockLocation =
+        mock(Location::class.java).apply {
+          `when`(latitude).thenReturn(48.8566)
+          `when`(longitude).thenReturn(2.3522)
+        }
+    val locationResult = LocationResult.create(listOf(mockLocation))
+
+    doAnswer { invocation ->
+          val callback = invocation.arguments[1] as LocationCallback
+          callback.onLocationResult(locationResult)
+          Tasks.forResult(null)
+        }
+        .`when`(fusedLocationClient)
+        .requestLocationUpdates(
+            any(LocationRequest::class.java), any(LocationCallback::class.java), any())
+
+    var receivedLocation: Location? = null
+    var error: Exception? = null
+
+    repository.getCurrentLocation(
+        onSuccess = { location -> receivedLocation = location },
+        onFailure = { exception -> error = exception })
+
+    assertNotNull(receivedLocation)
+    assertEquals(48.8566, receivedLocation?.latitude)
+    assertEquals(2.3522, receivedLocation?.longitude)
+    assertNull(error)
+  }
+}

--- a/app/src/test/java/com/github/se/travelpouch/model/gps/GPSViewModelTest.kt
+++ b/app/src/test/java/com/github/se/travelpouch/model/gps/GPSViewModelTest.kt
@@ -1,0 +1,126 @@
+package com.github.se.travelpouch.model.gps
+
+import android.location.Location
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GPSViewModelTest {
+
+  private lateinit var gpsRepository: GPSRepository
+  private lateinit var viewModel: GPSViewModel
+  private val testDispatcher = UnconfinedTestDispatcher()
+
+  @Before
+  fun setUp() {
+    // Mock the GPSRepository
+    gpsRepository = mock(GPSRepository::class.java)
+
+    // Set the dispatcher for coroutines
+    Dispatchers.setMain(testDispatcher)
+
+    // Instantiate the ViewModel with the mocked repository
+    viewModel = GPSViewModel(gpsRepository)
+  }
+
+  @After
+  fun tearDown() {
+    // Reset the main dispatcher to avoid affecting other tests
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun testRealTimeLocationUpdatesAfterStartingUpdates() = runBlocking {
+    // Simulate a LatLng
+    val mockLocation = LatLng(48.8566, 2.3522)
+
+    // Simulate repository emitting the location
+    `when`(gpsRepository.getGPSUpdatesForMap()).thenReturn(flow { emit(mockLocation) })
+
+    // Start real-time updates
+    viewModel.startRealTimeLocationUpdates()
+
+    // Collect the first emitted value from the ViewModel's StateFlow
+    val emittedLocation = viewModel.realTimeLocation.first()
+
+    // Verify the result
+    assertNotNull(emittedLocation)
+    assertEquals(48.8566, emittedLocation?.latitude)
+    assertEquals(2.3522, emittedLocation?.longitude)
+  }
+
+  @Test
+  fun testRealTimeLocationUpdatesHandlesNull() = runBlocking {
+    // Simulate the repository emitting null values
+    `when`(gpsRepository.getGPSUpdatesForMap()).thenReturn(flowOf(null))
+
+    // Collect the first emitted value from the ViewModel's StateFlow
+    val emittedLocation = viewModel.realTimeLocation.first()
+
+    // Verify the result is null
+    assertNull(emittedLocation)
+  }
+
+  @Test
+  fun testFetchCurrentLocationSuccess() = runBlocking {
+    // Simulate a successful location
+    val mockLocation =
+        mock(android.location.Location::class.java).apply {
+          `when`(latitude).thenReturn(48.8566)
+          `when`(longitude).thenReturn(2.3522)
+        }
+    // Simulate repository providing the location successfully
+    doAnswer {
+          val onSuccess = it.getArgument(0) as (Location) -> Unit
+          onSuccess(mockLocation)
+          null
+        }
+        .whenever(gpsRepository)
+        .getCurrentLocation(onSuccess = any(), onFailure = any())
+
+    // Call the ViewModel's method
+    viewModel.fetchCurrentLocation()
+
+    // Collect the first emitted value from the ViewModel's StateFlow
+    val emittedLocation = viewModel.singleLocationUpdate.first()
+
+    // Verify the result
+    assertNotNull(emittedLocation)
+    assertEquals(48.8566, emittedLocation?.latitude)
+    assertEquals(2.3522, emittedLocation?.longitude)
+  }
+
+  @Test
+  fun testFetchCurrentLocationFailure() = runBlocking {
+    // Simulate an error in location retrieval
+    doAnswer { invocation ->
+          val onFailure = invocation.arguments[1] as (Exception) -> Unit
+          onFailure(Exception("Location error"))
+          null
+        }
+        .`when`(gpsRepository)
+        .getCurrentLocation(any<(android.location.Location) -> Unit>(), any())
+
+    // Call the ViewModel's method
+    viewModel.fetchCurrentLocation()
+
+    // Collect the first emitted value from the ViewModel's StateFlow
+    val emittedLocation = viewModel.singleLocationUpdate.first()
+
+    // Verify the result is null
+    assertNull(emittedLocation)
+  }
+}

--- a/app/src/test/java/com/github/se/travelpouch/model/gps/GPSViewModelTest.kt
+++ b/app/src/test/java/com/github/se/travelpouch/model/gps/GPSViewModelTest.kt
@@ -1,7 +1,13 @@
 package com.github.se.travelpouch.model.gps
 
+import android.content.Context
 import android.location.Location
+import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.model.LatLng
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -122,5 +128,33 @@ class GPSViewModelTest {
 
     // Verify the result is null
     assertNull(emittedLocation)
+  }
+
+  @Test
+  fun testGPSViewModelFactoryCreatesInstance() {
+    // Mock context
+    val mockContext = mock(Context::class.java)
+
+    // Mock fused location client
+    val mockFusedLocationProviderClient =
+        mockk<com.google.android.gms.location.FusedLocationProviderClient>()
+
+    // Mock the static method LocationServices.getFusedLocationProviderClient
+    mockkStatic(LocationServices::class)
+    every { LocationServices.getFusedLocationProviderClient(mockContext) } returns
+        mockFusedLocationProviderClient
+
+    // Create the factory
+    val factory = GPSViewModel.Factory(mockContext)
+
+    // Use the factory to create an instance of GPSViewModel
+    val viewModel = factory.create(GPSViewModel::class.java)
+
+    // Verify the instance
+    assertNotNull(viewModel)
+    assertTrue(viewModel is GPSViewModel)
+
+    // Clean up the static mock
+    unmockkStatic(LocationServices::class)
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ navigationTesting = "2.8.3"
 playServicesMlkitDocumentScanner = "16.0.0-beta1"
 coil = "2.1.0"
 bouquet = "1.1.2"
+playServicesLocation = "21.3.0"
 
 [libraries]
 androidx-concurrent-futures = { module = "androidx.concurrent:concurrent-futures", version.ref = "concurrentFutures" }
@@ -147,6 +148,7 @@ play-services-mlkit-document-scanner = { group = "com.google.android.gms", name 
 firebase-functions-ktx = { group = "com.google.firebase", name = "firebase-functions-ktx", version.ref = "firebaseFunctionsKtx" }
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 bouquet = { group = "io.github.grizzi91", name = "bouquet", version.ref = "bouquet" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This PR implements the `GPSRepository` and `GPSViewModel`  to handle GPS location updates. 
It allows for continuous geolocation updates and the possibility to make single location requests.