### PR TITLE
UI: Stow away map and clickable map waypoint

### DIFF
--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/home/TravelListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/home/TravelListScreenTest.kt
@@ -1,8 +1,14 @@
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
 import com.github.se.travelpouch.helper.FileDownloader
 import com.github.se.travelpouch.model.activity.ActivityRepository
 import com.github.se.travelpouch.model.activity.ActivityViewModel
@@ -25,6 +31,7 @@ import com.github.se.travelpouch.ui.navigation.NavigationActions
 import com.github.se.travelpouch.ui.navigation.Screen
 import com.google.firebase.Timestamp
 import java.util.Date
+import kotlin.math.roundToInt
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
@@ -266,7 +273,7 @@ class TravelListScreenTest {
   }
 
   @Test
-  fun displayEmptyTravelList() {
+  fun displayEmptyTravelListAndDragStowawayMap() {
     // Arrange
     val emptyTravelList = emptyList<TravelContainer>()
     doAnswer { invocation ->
@@ -291,5 +298,107 @@ class TravelListScreenTest {
 
     // Assert
     composeTestRule.onNodeWithTag("emptyTravelPrompt").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("mapLatch").assertIsDisplayed()
+    val density = composeTestRule.density
+    val heightBefore =
+        (composeTestRule.onNodeWithTag("mapScreen").captureToImage().height / density.density)
+            .roundToInt()
+    var dragDistance = 100 // For example, drag it 100 dp vertically
+    val correctionFactor = 8 // somehow all values are off by 8 dp
+    // we drag it up by 100 dp
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), -(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule
+        .onNodeWithTag("mapScreen")
+        .assertHeightIsEqualTo((heightBefore - dragDistance).dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
+    // we drag it down by 100 dp
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), +(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule.onNodeWithTag("mapScreen").assertHeightIsEqualTo(heightBefore.dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
+
+    // we over-drag it to see that nothing changes
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), +(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule.onNodeWithTag("mapScreen").assertHeightIsEqualTo(heightBefore.dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
+
+    // we will drag it down by 160 dp so we have map size at 270 - 160 = 110 dp because it's 10 dp
+    // before the threshold for closer
+    dragDistance = 160
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), -(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule
+        .onNodeWithTag("mapScreen")
+        .assertHeightIsEqualTo((heightBefore - dragDistance).dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
+    // we will drag it down by 15 dp, so we hit 95 dp, this should lead to the map closing itself
+    dragDistance = 15
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), -(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule.onNodeWithTag("mapScreen").assertHeightIsEqualTo(0.dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsNotDisplayed()
+    // we will now drag it up by 50 dp, and it shouldn't snap back to 0 dp
+    dragDistance = 50
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), +(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule.onNodeWithTag("mapScreen").assertHeightIsEqualTo(dragDistance.dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
+    // we will now drag it up by 60 dp, and this means we're in the zone where the snap to 0 is
+    // available again
+    dragDistance = 60
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), +(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule.onNodeWithTag("mapScreen").assertHeightIsEqualTo(110.dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
+    // now it we drag it down again by 20dp, we should hit the threshold and it should close
+    dragDistance = 20
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), -(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule.onNodeWithTag("mapScreen").assertHeightIsEqualTo(0.dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsNotDisplayed()
+    // now we drag it up and it shouldn't change anything
+    dragDistance = 20
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), -(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule.onNodeWithTag("mapScreen").assertHeightIsEqualTo(0.dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsNotDisplayed()
+    // and now we don't have any "drag" debt so it we drag it back by 60 dp, it should open
+    dragDistance = 60
+    composeTestRule.onNodeWithTag("mapLatch").performTouchInput {
+      down(center) // Start the drag at the center of the mapLatch
+      moveBy(Offset(0.dp.toPx(), +(dragDistance + correctionFactor).dp.toPx()))
+      up() // End the drag
+    }
+    composeTestRule.onNodeWithTag("mapScreen").assertHeightIsEqualTo(60.dp)
+    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/github/se/travelpouch/ui/home/Map.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/home/Map.kt
@@ -104,18 +104,6 @@ fun MapContent(
 }
 
 // credit to https://dev.to/bubenheimer/effective-map-composables-non-draggable-markers-2b2
-/**
- * Composable function that displays a simple marker on the map.
- *
- * @param position The position of the marker.
- * @param title Optional title for the marker.
- * @param snippet Optional snippet for the marker.
- */
-@Composable
-fun SimpleMarker(position: LatLng, title: String? = null, snippet: String? = null) {
-  val state = rememberUpdatedMarkerState(position)
-  Marker(state = state, title = title, snippet = snippet)
-}
 
 /**
  * Composable function that displays a clickable marker on the map.

--- a/app/src/main/java/com/github/se/travelpouch/ui/home/Map.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/home/Map.kt
@@ -84,7 +84,6 @@ fun MapContent(
               title = travelContainer.title,
               snippet = travelContainer.description,
               onInfoWindowClick = { marker ->
-                Log.d("MapScreen", "Marker clicked: ${marker.tag}")
                 val foundTravelContainer = markers.find { it.fsUid == marker.tag }
                 if (foundTravelContainer != null) {
                   Log.d("MapScreen", "Travel container clicked: ${foundTravelContainer.title}")

--- a/app/src/main/java/com/github/se/travelpouch/ui/home/Map.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/home/Map.kt
@@ -1,5 +1,8 @@
 package com.github.se.travelpouch.ui.home
 
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -7,10 +10,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import com.github.se.travelpouch.model.travels.TravelContainer
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Marker
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerState
@@ -35,12 +40,18 @@ fun MapScreen(travelContainers: List<TravelContainer>) {
  *
  * @param modifier Modifier for customizing the layout.
  * @param travelContainers List of travel containers to be displayed as markers on the map.
+ * @param onInfoWindowClickCallback Callback function to be invoked when a marker info window is
+ *   clicked.
  */
 @Composable
-fun MapContent(modifier: Modifier = Modifier, travelContainers: List<TravelContainer>) {
+fun MapContent(
+    modifier: Modifier = Modifier,
+    travelContainers: List<TravelContainer>,
+    onInfoWindowClickCallback: (TravelContainer) -> Unit = {}
+) {
 
   val markers = travelContainers.filter { true }
-
+  val context: Context = LocalContext.current
   val cameraPositionState = rememberCameraPositionState {
     // Set initial camera position to the first TravelContainer's location or a default
     if (markers.isNotEmpty()) {
@@ -68,10 +79,26 @@ fun MapContent(modifier: Modifier = Modifier, travelContainers: List<TravelConta
         markers.forEach { travelContainer ->
           val location = travelContainer.location
           val position = LatLng(location.latitude, location.longitude)
-          SimpleMarker(
+          ClickableSimpleMarker(
               position = position,
               title = travelContainer.title,
-              snippet = travelContainer.description)
+              snippet = travelContainer.description,
+              onInfoWindowClick = { marker ->
+                Log.d("MapScreen", "Marker clicked: ${marker.tag}")
+                val foundTravelContainer = markers.find { it.fsUid == marker.tag }
+                if (foundTravelContainer != null) {
+                  Log.d("MapScreen", "Travel container clicked: ${foundTravelContainer.title}")
+                  onInfoWindowClickCallback(foundTravelContainer)
+                } else {
+                  Log.e("MapScreen", "No travel container found for marker tag: ${marker.tag}")
+                  Toast.makeText(
+                          context,
+                          "No travel container found for marker tag: ${marker.tag}",
+                          Toast.LENGTH_LONG)
+                      .show()
+                }
+              },
+              tag = travelContainer.fsUid)
         }
       }
 }
@@ -88,6 +115,32 @@ fun MapContent(modifier: Modifier = Modifier, travelContainers: List<TravelConta
 fun SimpleMarker(position: LatLng, title: String? = null, snippet: String? = null) {
   val state = rememberUpdatedMarkerState(position)
   Marker(state = state, title = title, snippet = snippet)
+}
+
+/**
+ * Composable function that displays a clickable marker on the map.
+ *
+ * @param position The position of the marker.
+ * @param title Optional title for the marker.
+ * @param snippet Optional snippet for the marker.
+ * @param onInfoWindowClick A lambda function to be called when the info window is clicked.
+ * @param tag Optional tag to associate with the marker.
+ */
+@Composable
+fun ClickableSimpleMarker(
+    position: LatLng,
+    title: String? = null,
+    snippet: String? = null,
+    onInfoWindowClick: (Marker) -> Unit = {},
+    tag: Any? = null
+) {
+  val state = rememberUpdatedMarkerState(position)
+  Marker(
+      state = state,
+      title = title,
+      snippet = snippet,
+      onInfoWindowClick = onInfoWindowClick,
+      tag = tag)
 }
 
 /**

--- a/app/src/main/java/com/github/se/travelpouch/ui/home/TravelList.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/home/TravelList.kt
@@ -98,7 +98,7 @@ fun TravelListScreen(
   // Used for the screen orientation redraw
   val configuration = LocalConfiguration.current
   val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
-  val mapHeight = if (isPortrait) 500.dp else 200.dp
+  val mapHeight = if (isPortrait) 300.dp else 200.dp
 
   Scaffold(
       modifier = Modifier.testTag("TravelListScreen"),

--- a/app/src/main/java/com/github/se/travelpouch/ui/home/TravelList.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/home/TravelList.kt
@@ -4,16 +4,9 @@ import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.icu.text.SimpleDateFormat
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
@@ -22,12 +15,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
@@ -36,8 +26,6 @@ import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.rounded.KeyboardArrowDown
-import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CircularProgressIndicator
@@ -49,31 +37,21 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.Recomposer
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import com.github.se.travelpouch.R
 import com.github.se.travelpouch.model.activity.ActivityViewModel
 import com.github.se.travelpouch.model.documents.DocumentViewModel
 import com.github.se.travelpouch.model.events.EventViewModel
@@ -85,7 +63,6 @@ import com.github.se.travelpouch.ui.navigation.NavigationActions
 import com.github.se.travelpouch.ui.navigation.Screen
 import com.github.se.travelpouch.ui.navigation.TopLevelDestinations
 import java.util.Locale
-import kotlin.math.roundToInt
 
 /**
  * Composable function for the travels list screen.
@@ -137,10 +114,10 @@ fun TravelListScreen(
         Column(modifier = Modifier.fillMaxSize().padding(pd)) {
           // Map placed outside the LazyColumn to prevent it from being part of the scrollable
           // content
-//          MapContent(
-//              modifier = Modifier.fillMaxWidth().height(mapHeight),
-//              travelContainers = travelList.value)
-            ResizableStowableMapWithGoogleMap(mapHeight,travelList)
+          //          MapContent(
+          //              modifier = Modifier.fillMaxWidth().height(mapHeight),
+          //              travelContainers = travelList.value)
+          ResizableStowableMapWithGoogleMap(mapHeight, travelList)
 
           LazyColumn(
               modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
@@ -248,84 +225,79 @@ fun TravelItem(travelContainer: TravelContainer, onClick: () -> Unit) {
       }
 }
 
-// inspired from : https://developer.android.com/develop/ui/compose/touch-input/pointer-input/drag-swipe-fling
+// inspired from :
+// https://developer.android.com/develop/ui/compose/touch-input/pointer-input/drag-swipe-fling
 @Composable
-fun ResizableStowableMapWithGoogleMap(maxMapHeightDp: Dp = 300.dp, travelList: State<List<TravelContainer>>) {
+fun ResizableStowableMapWithGoogleMap(
+    maxMapHeightDp: Dp = 300.dp,
+    travelList: State<List<TravelContainer>>
+) {
 
-    // State to track the height of the map
+  // State to track the height of the map
 
-    val minHeightPx = 100f // Min height of the map (collapsed state)
-    val latchDp = 30.dp // Height of the strap handle
-    val maxHeightPx = maxMapHeightDp.value + latchDp.value// Max height of the map
-    val mapHeight = remember { mutableStateOf(maxHeightPx) }  // Initial height of the map in pixels
-    val density = LocalDensity.current // Get the density scale factor
+  val minHeightPx = 100f // Min height of the map (collapsed state)
+  val latchDp = 30.dp // Height of the strap handle
+  val maxHeightPx = maxMapHeightDp.value + latchDp.value // Max height of the map
+  val mapHeight = remember { mutableStateOf(maxHeightPx) } // Initial height of the map in pixels
+  val density = LocalDensity.current // Get the density scale factor
 
-    // Track whether the map is collapsed (height is 0)
-    val isCollapsed = remember { mutableStateOf(false) }
+  // Track whether the map is collapsed (height is 0)
+  val isCollapsed = remember { mutableStateOf(false) }
 
-    Column (
-        modifier = Modifier
-            .fillMaxWidth()
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .requiredHeight(mapHeight.value.dp)
-        ) {
-            MapContent(
-              modifier = Modifier.fillMaxWidth().height(mapHeight.value.dp),
-              travelContainers = travelList.value)
-        }
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Box(modifier = Modifier.fillMaxWidth().requiredHeight(mapHeight.value.dp)) {
+      MapContent(
+          modifier = Modifier.fillMaxWidth().height(mapHeight.value.dp),
+          travelContainers = travelList.value)
+    }
 
-        // Strap handle at the bottom to drag and resize the map
-        Box(
-            modifier = Modifier
-                //.align(Alignment.BottomCenter)
+    // Strap handle at the bottom to drag and resize the map
+    Box(
+        modifier =
+            Modifier
+                // .align(Alignment.BottomCenter)
                 .fillMaxWidth()
                 .graphicsLayer {
-                    shape = CutCornerShape(
-                        topStart = 0.dp, // Adjust these values for the trapezoidal effect
-                        topEnd = 0.dp,
-                        bottomStart = 16.dp,
-                        bottomEnd = 16.dp
-                    )
-                    clip = true
+                  shape =
+                      CutCornerShape(
+                          topStart = 0.dp, // Adjust these values for the trapezoidal effect
+                          topEnd = 0.dp,
+                          bottomStart = 16.dp,
+                          bottomEnd = 16.dp)
+                  clip = true
                 }
                 .height(30.dp)
                 .background(Color.Blue)
                 .draggable(
                     orientation = Orientation.Vertical,
-                    state = rememberDraggableState { delta ->
+                    state =
+                        rememberDraggableState { delta ->
+                          val scaledDelta =
+                              delta / density.density // Adjusting by the density scale factor
 
-                        val scaledDelta = delta / density.density // Adjusting by the density scale factor
-
-                        // Calculate the new map height based on the delta drag amount
-                        if(mapHeight.value + scaledDelta > maxHeightPx) {
+                          // Calculate the new map height based on the delta drag amount
+                          if (mapHeight.value + scaledDelta > maxHeightPx) {
                             mapHeight.value = maxHeightPx
-                        }
-                        else if (mapHeight.value + scaledDelta < minHeightPx && !isCollapsed.value) {
+                          } else if (mapHeight.value + scaledDelta < minHeightPx &&
+                              !isCollapsed.value) {
                             isCollapsed.value = true
                             mapHeight.value = 0f
-                        }
-                        else {
+                          } else {
                             if (isCollapsed.value && mapHeight.value + scaledDelta > minHeightPx) {
-                                isCollapsed.value = false
+                              isCollapsed.value = false
                             }
                             // clamp the to the min value to avoid
                             if (mapHeight.value + scaledDelta < 0) {
-                                mapHeight.value = 0f
+                              mapHeight.value = 0f
                             } else {
-                                mapHeight.value += scaledDelta
+                              mapHeight.value += scaledDelta
                             }
-                        }
-                    }
-                )
-        ) {
-            Text(
-                text = "Drag to resize or stow",
-                color = Color.White,
-                modifier = Modifier.align(Alignment.Center)
-            )
+                          }
+                        })) {
+          Text(
+              text = "Drag to resize or stow",
+              color = Color.White,
+              modifier = Modifier.align(Alignment.Center))
         }
-    }
+  }
 }

--- a/app/src/main/java/com/github/se/travelpouch/ui/home/TravelList.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/home/TravelList.kt
@@ -4,21 +4,40 @@ import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.icu.text.SimpleDateFormat
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CircularProgressIndicator
@@ -30,14 +49,31 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.github.se.travelpouch.R
 import com.github.se.travelpouch.model.activity.ActivityViewModel
 import com.github.se.travelpouch.model.documents.DocumentViewModel
 import com.github.se.travelpouch.model.events.EventViewModel
@@ -49,6 +85,7 @@ import com.github.se.travelpouch.ui.navigation.NavigationActions
 import com.github.se.travelpouch.ui.navigation.Screen
 import com.github.se.travelpouch.ui.navigation.TopLevelDestinations
 import java.util.Locale
+import kotlin.math.roundToInt
 
 /**
  * Composable function for the travels list screen.
@@ -100,9 +137,10 @@ fun TravelListScreen(
         Column(modifier = Modifier.fillMaxSize().padding(pd)) {
           // Map placed outside the LazyColumn to prevent it from being part of the scrollable
           // content
-          MapContent(
-              modifier = Modifier.fillMaxWidth().height(mapHeight),
-              travelContainers = travelList.value)
+//          MapContent(
+//              modifier = Modifier.fillMaxWidth().height(mapHeight),
+//              travelContainers = travelList.value)
+            ResizableStowableMapWithGoogleMap(mapHeight,travelList)
 
           LazyColumn(
               modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
@@ -208,4 +246,86 @@ fun TravelItem(travelContainer: TravelContainer, onClick: () -> Unit) {
               fontWeight = FontWeight.Light)
         }
       }
+}
+
+// inspired from : https://developer.android.com/develop/ui/compose/touch-input/pointer-input/drag-swipe-fling
+@Composable
+fun ResizableStowableMapWithGoogleMap(maxMapHeightDp: Dp = 300.dp, travelList: State<List<TravelContainer>>) {
+
+    // State to track the height of the map
+
+    val minHeightPx = 100f // Min height of the map (collapsed state)
+    val latchDp = 30.dp // Height of the strap handle
+    val maxHeightPx = maxMapHeightDp.value + latchDp.value// Max height of the map
+    val mapHeight = remember { mutableStateOf(maxHeightPx) }  // Initial height of the map in pixels
+    val density = LocalDensity.current // Get the density scale factor
+
+    // Track whether the map is collapsed (height is 0)
+    val isCollapsed = remember { mutableStateOf(false) }
+
+    Column (
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .requiredHeight(mapHeight.value.dp)
+        ) {
+            MapContent(
+              modifier = Modifier.fillMaxWidth().height(mapHeight.value.dp),
+              travelContainers = travelList.value)
+        }
+
+        // Strap handle at the bottom to drag and resize the map
+        Box(
+            modifier = Modifier
+                //.align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .graphicsLayer {
+                    shape = CutCornerShape(
+                        topStart = 0.dp, // Adjust these values for the trapezoidal effect
+                        topEnd = 0.dp,
+                        bottomStart = 16.dp,
+                        bottomEnd = 16.dp
+                    )
+                    clip = true
+                }
+                .height(30.dp)
+                .background(Color.Blue)
+                .draggable(
+                    orientation = Orientation.Vertical,
+                    state = rememberDraggableState { delta ->
+
+                        val scaledDelta = delta / density.density // Adjusting by the density scale factor
+
+                        // Calculate the new map height based on the delta drag amount
+                        if(mapHeight.value + scaledDelta > maxHeightPx) {
+                            mapHeight.value = maxHeightPx
+                        }
+                        else if (mapHeight.value + scaledDelta < minHeightPx && !isCollapsed.value) {
+                            isCollapsed.value = true
+                            mapHeight.value = 0f
+                        }
+                        else {
+                            if (isCollapsed.value && mapHeight.value + scaledDelta > minHeightPx) {
+                                isCollapsed.value = false
+                            }
+                            // clamp the to the min value to avoid
+                            if (mapHeight.value + scaledDelta < 0) {
+                                mapHeight.value = 0f
+                            } else {
+                                mapHeight.value += scaledDelta
+                            }
+                        }
+                    }
+                )
+        ) {
+            Text(
+                text = "Drag to resize or stow",
+                color = Color.White,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/github/se/travelpouch/ui/home/TravelList.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/home/TravelList.kt
@@ -308,6 +308,7 @@ fun ResizableStowableMapWithGoogleMap(
     Box(
         modifier =
             Modifier.fillMaxWidth()
+                .testTag("mapLatch")
                 .graphicsLayer {
                   shape =
                       CutCornerShape(
@@ -366,7 +367,7 @@ private fun resizeFromDragMotion(
     if (mapHeight.floatValue + scaledDelta < 0) {
       mapHeight.floatValue = 0f
     } else {
-      mapHeight.value += scaledDelta
+      mapHeight.floatValue += scaledDelta
     }
   }
 }


### PR DESCRIPTION
copied from #209

Description: Main screen map should be able to be stowed away like a drawer when the map is not needed. This gives the user more space to inspect and choose a travel.
Furthermore, we want to make travel selection based on location easier. Thus, the map markers are clickable and leads to a travel.

Acceptance Criteria:
Stow away

    Map on the main screen should have a small snippet that one can touch
    When dragging the snippet, the map should follow and be resized dynamically and the list of travels too.
    Map should be able to be completely stowed away
    Clickable markers
    Each marker on the map should be clickable.
    When one clicks on the marker name or description, the application should navigate to travel's activities screen.

This PR closes #209