### PR TITLE
feat: add travel mode in ActivitiesMapScreen

### DIFF
--- a/app/src/androidTest/java/com/github/se/travelpouch/ui/dashboard/map/ActivitiesMapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/travelpouch/ui/dashboard/map/ActivitiesMapScreenTest.kt
@@ -2,6 +2,7 @@ package com.github.se.travelpouch.ui.dashboard.map
 
 import android.Manifest
 import android.content.pm.PackageManager
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -182,7 +183,13 @@ class ActivitiesMapScreenTest {
 
   @Test
   fun testActivityDetailsContentDisplaysCorrectDetails() {
-    composeTestRule.setContent { ActivityDetailsContent(activity = listOfActivities[0]) }
+    composeTestRule.setContent {
+      ActivityDetailsContent(
+          activity = listOfActivities[0], // Pass the first activity
+          isGPSAvailable = true, // Mock GPS availability
+          onShowPathGPS = {} // Provide a no-op lambda for the callback
+          )
+    }
 
     // Verify title
     composeTestRule.onNodeWithTag("ActivityTitle").assertExists().assertTextEquals("Team Meeting")
@@ -218,9 +225,11 @@ class ActivitiesMapScreenTest {
                       listOf(
                           listOf(
                               LatLng(48.8566, 2.3522),
-                              LatLng(48.8570, 2.3530)) // Mock GPS to activity route
-                          )),
-          selectedActivity = listOfActivities[0] // Mock selected activity
+                              LatLng(48.8570, 2.3530) // Mock GPS to activity route
+                              ))),
+          selectedActivity = listOfActivities[0], // Mock selected activity
+          travelMode = "walking", // Mock travel mode
+          onTravelModeSelected = {} // No-op lambda for testing
           )
     }
 
@@ -228,7 +237,7 @@ class ActivitiesMapScreenTest {
     composeTestRule
         .onNodeWithTag("RouteDetailsTitle_Gps")
         .assertExists()
-        .assertTextEquals("Your current Location")
+        .assertTextEquals("Your Current Location")
 
     // Verify distance
     composeTestRule
@@ -265,8 +274,10 @@ class ActivitiesMapScreenTest {
                           listOf(LatLng(48.8566, 2.3522), LatLng(48.8570, 2.3530)), // Mock leg 1
                           listOf(LatLng(48.8570, 2.3530), LatLng(49.8566, 2.3522)) // Mock leg 2
                           )),
-          legIndex = 0,
-          activities = listOfActivities)
+          legIndex = 0, // Testing the first leg
+          activities = listOfActivities,
+          travelMode = "walking" // Mock travel mode
+          )
     }
 
     // Verify title (start activity)
@@ -292,6 +303,77 @@ class ActivitiesMapScreenTest {
         .onNodeWithTag("RouteDetailsSubtitle_Leg")
         .assertExists()
         .assertTextEquals("Client Presentation")
+  }
+
+  @Test
+  fun testTravelModeButtonActivities() {
+    var showPathsState = false
+    var selectedTravelMode = "walking"
+
+    composeTestRule.setContent {
+      TravelModeButtonActivities(
+          showPaths = showPathsState,
+          onTogglePaths = { showPathsState = !showPathsState },
+          travelMode = selectedTravelMode,
+          onTravelModeChange = { mode -> selectedTravelMode = mode })
+    }
+
+    // Verify initial state of toggle button
+    composeTestRule.onNodeWithTag("ToggleModeButtonActivities").assertExists()
+
+    // Click the toggle button to enable paths
+    composeTestRule.onNodeWithTag("ToggleModeButtonActivities").performClick()
+    assert(showPathsState) // Verify state is updated
+
+    // Verify "Walking Mode" button exists
+    composeTestRule.onNodeWithTag("WalkingModeButtonActivities").assertExists()
+
+    // Switch to "Driving Mode"
+    composeTestRule.onNodeWithTag("WalkingModeButtonActivities").performClick()
+    assert(selectedTravelMode == "walking") // Verify state is updated
+
+    // Verify "Driving Mode" button exists
+    composeTestRule.onNodeWithTag("DrivingModeButtonActivities").assertExists()
+
+    // Switch to "Driving Mode"
+    composeTestRule.onNodeWithTag("DrivingModeButtonActivities").performClick()
+    assert(selectedTravelMode == "driving") // Verify state is updated
+
+    // Verify "Bicycling Mode" button exists
+    composeTestRule.onNodeWithTag("BicyclingModeButtonActivities").assertExists()
+
+    // Switch to "Bicycling Mode"
+    composeTestRule.onNodeWithTag("BicyclingModeButtonActivities").performClick()
+    assert(selectedTravelMode == "bicycling") // Verify state is updated
+  }
+
+  @Test
+  fun testTravelModesGPS() {
+    var selectedMode = "walking"
+
+    composeTestRule.setContent {
+      TravelModesGPS(selectedMode = selectedMode, onModeSelected = { mode -> selectedMode = mode })
+    }
+
+    // Switch to "walking" mode
+    composeTestRule.onNodeWithTag("WalkingModeButtonGPS").assertExists()
+    composeTestRule.onNodeWithTag("WalkingModeButtonGPS").performClick()
+    assert(selectedMode == "walking") // Verify initial mode
+
+    // Switch to "Car" mode
+    composeTestRule.onNodeWithTag("DrivingModeButtonGPS").assertExists()
+    composeTestRule.onNodeWithTag("DrivingModeButtonGPS").performClick()
+    assert(selectedMode == "driving") // Verify mode is updated
+
+    // Switch to "Bicycle" mode
+    composeTestRule.onNodeWithTag("BicyclingModeButtonGPS").assertExists()
+    composeTestRule.onNodeWithTag("BicyclingModeButtonGPS").performClick()
+    assert(selectedMode == "bicycling") // Verify mode is updated
+
+    // Switch to "None" mode
+    composeTestRule.onNodeWithTag("NoneModeButtonGPS").assertExists()
+    composeTestRule.onNodeWithTag("NoneModeButtonGPS").performClick()
+    assert(selectedMode == "None") // Verify mode is updated
   }
 }
 

--- a/app/src/main/java/com/github/se/travelpouch/model/activity/map/DirectionsViewModel.kt
+++ b/app/src/main/java/com/github/se/travelpouch/model/activity/map/DirectionsViewModel.kt
@@ -161,10 +161,12 @@ class DirectionsViewModel(private val repository: DirectionsRepositoryInterface)
               targetStateFlow.value = routeDetails
             } else {
               Log.e("DirectionsViewModel", "Failed to extract route details")
+              targetStateFlow.value = RouteDetails.EMPTY
             }
           },
           onFailure = { exception ->
             Log.e("DirectionsViewModel", "Failed to fetch directions", exception)
+            targetStateFlow.value = RouteDetails.EMPTY
           })
     }
   }

--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/map/ActivitiesMapScreen.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/map/ActivitiesMapScreen.kt
@@ -1,6 +1,10 @@
 package com.github.se.travelpouch.ui.dashboard.map
 
 import android.util.Log
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,18 +17,30 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Directions
+import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberStandardBottomSheetState
@@ -39,6 +55,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -131,23 +148,36 @@ fun ActivitiesMapScreen(
   // Collect the current location from GPSViewModel as a Compose state
   val currentLocation by gpsViewModel.realTimeLocation.collectAsState()
 
+  var isGPSAvailable by remember { mutableStateOf(false) }
   // Request location permission and start location updates when permission is granted
   LocationPermissionComposable(
       onPermissionGranted = {
         Log.d("ActivitiesMapScreen", "Location permission granted.")
+        isGPSAvailable = true
         gpsViewModel.startRealTimeLocationUpdates()
       },
-      onPermissionDenied = { Log.d("ActivitiesMapScreen", "Location permission denied.") })
+      onPermissionDenied = {
+        Log.d("ActivitiesMapScreen", "Location permission denied.")
+        isGPSAvailable = false
+      })
+
+  // State to track whether to show paths
+  var showPathsActivities by remember { mutableStateOf(false) }
+  var showPathsGPS by remember { mutableStateOf(false) }
+
+  // State to track the travel mode for directions
+  var travelModeActivities by remember { mutableStateOf("walking") }
+  var travelModeGPS by remember { mutableStateOf("walking") }
 
   // Fetch directions for the valid activities
-  LaunchedEffect(validActivities) {
+  LaunchedEffect(travelModeActivities, validActivities) {
     // Fetch directions if the list of activities changes
-    directionsViewModel.fetchDirectionsForActivities(validActivities, "walking")
+    directionsViewModel.fetchDirectionsForActivities(validActivities, travelModeActivities)
   }
 
   // Fetch directions for the selected activity and GPS location
-  LaunchedEffect(selectedActivity) {
-    directionsViewModel.fetchDirectionsForGps(currentLocation, selectedActivity, "walking")
+  LaunchedEffect(travelModeGPS, selectedActivity) {
+    directionsViewModel.fetchDirectionsForGps(currentLocation, selectedActivity, travelModeGPS)
   }
 
   // Update the camera position when the valid activities change
@@ -163,6 +193,15 @@ fun ActivitiesMapScreen(
   var bottomSheetContent by remember { mutableStateOf<@Composable () -> Unit>({}) }
 
   val scope = rememberCoroutineScope()
+
+  // Function to handle travel mode selection
+  val onTravelModeSelectedGPS: (String) -> Unit = { mode ->
+    travelModeGPS = mode
+    showPathsGPS = mode != "None" // Hide paths if "none" is selected
+    if (mode == "None") {
+      scope.launch { bottomSheetScaffoldState.bottomSheetState.hide() }
+    }
+  }
 
   BottomSheetScaffold(
       scaffoldState = bottomSheetScaffoldState,
@@ -182,30 +221,49 @@ fun ActivitiesMapScreen(
                     activities = validActivities,
                     dateFormat = dateFormat,
                     onActivitySelected = {
-                      selectedActivity = it
-
-                      bottomSheetContent = { ActivityDetailsContent(it) }
-                      scope.launch { bottomSheetScaffoldState.bottomSheetState.expand() }
-                    })
-
-                DrawActivitiesPaths(
-                    activitiesRouteDetails = activitiesRouteDetails,
-                    selectedRouteIndex = selectedRouteIndex,
-                    onRouteSelected = {
-                      selectedRouteIndex = it
-
                       bottomSheetContent = {
-                        LegDetailsContent(activitiesRouteDetails, it, validActivities)
+                        ActivityDetailsContent(it, isGPSAvailable) { activity ->
+                          showPathsGPS = true
+                          selectedActivity = it
+                          travelModeGPS = "walking"
+                          bottomSheetContent = {
+                            GpsDetailsContent(
+                                gpsRouteDetails, activity, travelModeGPS, onTravelModeSelectedGPS)
+                          }
+                        }
                       }
                       scope.launch { bottomSheetScaffoldState.bottomSheetState.expand() }
                     })
 
-                DrawGpsToActivityPath(
-                    gpsRouteDetails = gpsRouteDetails,
-                    onRouteSelected = {
-                      bottomSheetContent = { GpsDetailsContent(gpsRouteDetails, selectedActivity) }
-                      scope.launch { bottomSheetScaffoldState.bottomSheetState.expand() }
-                    })
+                if (showPathsActivities) {
+                  DrawActivitiesPaths(
+                      activitiesRouteDetails = activitiesRouteDetails,
+                      selectedRouteIndex = selectedRouteIndex,
+                      onRouteSelected = {
+                        selectedRouteIndex = it
+
+                        bottomSheetContent = {
+                          LegDetailsContent(
+                              activitiesRouteDetails, it, validActivities, travelModeActivities)
+                        }
+                        scope.launch { bottomSheetScaffoldState.bottomSheetState.expand() }
+                      })
+                }
+
+                if (showPathsGPS) {
+                  DrawGpsToActivityPath(
+                      gpsRouteDetails = gpsRouteDetails,
+                      onRouteSelected = {
+                        bottomSheetContent = {
+                          GpsDetailsContent(
+                              gpsRouteDetails,
+                              selectedActivity,
+                              travelModeGPS,
+                              onTravelModeSelectedGPS)
+                        }
+                        scope.launch { bottomSheetScaffoldState.bottomSheetState.expand() }
+                      })
+                }
               }
 
           // Add a floating action button for going back
@@ -218,7 +276,164 @@ fun ActivitiesMapScreen(
                       .testTag("GoBackButton")) {
                 Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = "Go Back")
               }
+
+          // Add a floating action button for toggling paths and travel modes
+          Box(
+              modifier = Modifier.fillMaxSize().padding(16.dp),
+              contentAlignment = Alignment.TopEnd) {
+                TravelModeButtonActivities(
+                    showPaths = showPathsActivities,
+                    onTogglePaths = { showPathsActivities = !showPathsActivities },
+                    travelMode = travelModeActivities,
+                    onTravelModeChange = { newMode -> travelModeActivities = newMode })
+              }
         }
+      }
+}
+
+// -------------------------------------------------
+// Helper Functions for displaying the travel mode buttons
+// -------------------------------------------------
+
+@Composable
+fun TravelModeButtonActivities(
+    showPaths: Boolean,
+    onTogglePaths: () -> Unit,
+    travelMode: String,
+    onTravelModeChange: (String) -> Unit
+) {
+
+  Column(
+      modifier =
+          Modifier.padding(16.dp)
+              .clip(RoundedCornerShape(16.dp))
+              .background(Color(0xB3FFFFFF)) // Fond semi-transparent
+              .padding(8.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        // Button to toggle paths
+        TravelModesActivitiesButton(
+            icon = if (showPaths) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+            contentDescription = if (showPaths) "Hide Paths" else "Show Paths",
+            isActive = showPaths,
+            onClick = onTogglePaths,
+            testTag = "ToggleModeButtonActivities")
+
+        // Travel mode buttons
+        TravelModesActivitiesButton(
+            icon = Icons.AutoMirrored.Filled.DirectionsWalk,
+            contentDescription = "Walking Mode",
+            isActive = travelMode == "walking",
+            onClick = { onTravelModeChange("walking") },
+            testTag = "WalkingModeButtonActivities")
+
+        TravelModesActivitiesButton(
+            icon = Icons.Filled.DirectionsCar,
+            contentDescription = "Driving Mode",
+            isActive = travelMode == "driving",
+            onClick = { onTravelModeChange("driving") },
+            testTag = "DrivingModeButtonActivities")
+
+        TravelModesActivitiesButton(
+            icon = Icons.Filled.DirectionsBike,
+            contentDescription = "Bicycling Mode",
+            isActive = travelMode == "bicycling",
+            onClick = { onTravelModeChange("bicycling") },
+            testTag = "BicyclingModeButtonActivities")
+      }
+}
+
+@Composable
+fun TravelModesActivitiesButton(
+    icon: ImageVector,
+    contentDescription: String,
+    isActive: Boolean,
+    onClick: () -> Unit,
+    testTag: String
+) {
+  val backgroundColor by
+      animateColorAsState(
+          targetValue =
+              if (isActive) Color.Blue.copy(alpha = 0.5f) else Color.Gray.copy(alpha = 0.2f))
+  val contentColor by animateColorAsState(targetValue = if (isActive) Color.White else Color.Black)
+
+  Box(
+      modifier =
+          Modifier.size(56.dp)
+              .clip(RoundedCornerShape(12.dp))
+              .background(backgroundColor)
+              .clickable(onClick = onClick)
+              .testTag(testTag),
+      contentAlignment = Alignment.Center) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = contentColor,
+            modifier = Modifier.size(24.dp))
+      }
+}
+
+@Composable
+fun TravelModesGPS(selectedMode: String, onModeSelected: (String) -> Unit) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(8.dp),
+      horizontalArrangement = Arrangement.SpaceEvenly) {
+        TravelModesGPSButton(
+            icon = Icons.Filled.DirectionsWalk,
+            contentDescription = "Walking",
+            isSelected = selectedMode == "walking",
+            onClick = { onModeSelected("walking") },
+            testTag = "WalkingModeButtonGPS")
+
+        TravelModesGPSButton(
+            icon = Icons.Filled.DirectionsCar,
+            contentDescription = "Car",
+            isSelected = selectedMode == "driving",
+            onClick = { onModeSelected("driving") },
+            testTag = "DrivingModeButtonGPS")
+        TravelModesGPSButton(
+            icon = Icons.Filled.DirectionsBike,
+            contentDescription = "Bicycle",
+            isSelected = selectedMode == "bicycling",
+            onClick = { onModeSelected("bicycling") },
+            testTag = "BicyclingModeButtonGPS")
+        TravelModesGPSButton(
+            icon = Icons.Filled.VisibilityOff,
+            contentDescription = "None",
+            isSelected = selectedMode == "None",
+            onClick = { onModeSelected("None") },
+            testTag = "NoneModeButtonGPS")
+      }
+}
+
+@Composable
+fun TravelModesGPSButton(
+    icon: ImageVector,
+    contentDescription: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    testTag: String
+) {
+  OutlinedButton(
+      onClick = { onClick() },
+      shape = MaterialTheme.shapes.medium,
+      colors =
+          ButtonDefaults.outlinedButtonColors(
+              containerColor =
+                  if (isSelected) MaterialTheme.colorScheme.primary
+                  else MaterialTheme.colorScheme.surface,
+              contentColor =
+                  if (isSelected) MaterialTheme.colorScheme.onPrimary
+                  else MaterialTheme.colorScheme.onSurface),
+      modifier = Modifier.testTag(testTag)) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint =
+                if (isSelected) MaterialTheme.colorScheme.onPrimary
+                else MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(24.dp) // Ensure size is set
+            )
       }
 }
 
@@ -234,7 +449,11 @@ fun ActivitiesMapScreen(
  * @param activity The activity to display.
  */
 @Composable
-fun ActivityDetailsContent(activity: Activity) {
+fun ActivityDetailsContent(
+    activity: Activity,
+    isGPSAvailable: Boolean,
+    onShowPathGPS: (Activity) -> Unit
+) {
   // Date formatter
   val dateFormatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
   val formattedDate = dateFormatter.format(activity.date.toDate())
@@ -290,6 +509,16 @@ fun ActivityDetailsContent(activity: Activity) {
               text = activity.description,
               testTag = "ActivityDescription")
         }
+
+        // Button to show path and navigate to GPS details
+        item {
+          Button(
+              onClick = { onShowPathGPS(activity) },
+              enabled = isGPSAvailable,
+              modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp)) {
+                Text("Show Path")
+              }
+        }
       }
 }
 
@@ -302,7 +531,12 @@ fun ActivityDetailsContent(activity: Activity) {
  * @param activities List of activities to determine start and end points.
  */
 @Composable
-fun LegDetailsContent(routeDetails: RouteDetails?, legIndex: Int, activities: List<Activity>) {
+fun LegDetailsContent(
+    routeDetails: RouteDetails?,
+    legIndex: Int,
+    activities: List<Activity>,
+    travelMode: String
+) {
   val startActivity = activities.getOrNull(legIndex)
   val endActivity = activities.getOrNull(legIndex + 1)
   val distance = routeDetails?.legsDistance?.getOrNull(legIndex) ?: "N/A"
@@ -310,6 +544,7 @@ fun LegDetailsContent(routeDetails: RouteDetails?, legIndex: Int, activities: Li
 
   RouteDetailsContent(
       title = startActivity?.title,
+      travelMode = travelMode,
       distance = distance,
       duration = duration,
       subtitle = endActivity?.title,
@@ -324,16 +559,28 @@ fun LegDetailsContent(routeDetails: RouteDetails?, legIndex: Int, activities: Li
  * @param selectedActivity The activity to which the route is displayed.
  */
 @Composable
-fun GpsDetailsContent(gpsRouteDetails: RouteDetails?, selectedActivity: Activity?) {
+fun GpsDetailsContent(
+    gpsRouteDetails: RouteDetails?,
+    selectedActivity: Activity?,
+    travelMode: String,
+    onTravelModeSelected: (String) -> Unit
+) {
   val distance = gpsRouteDetails?.legsDistance?.firstOrNull() ?: "N/A"
   val duration = gpsRouteDetails?.legsDuration?.firstOrNull() ?: "N/A"
 
-  RouteDetailsContent(
-      title = "Your current Location",
-      distance = distance,
-      duration = duration,
-      subtitle = selectedActivity?.title,
-      testTag = "Gps")
+  Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+    // Travel Mode Selection Row
+    TravelModesGPS(selectedMode = travelMode, onModeSelected = onTravelModeSelected)
+
+    // Display route details
+    RouteDetailsContent(
+        title = "Your Current Location",
+        travelMode = travelMode,
+        distance = distance,
+        duration = duration,
+        subtitle = selectedActivity?.title,
+        testTag = "Gps")
+  }
 }
 
 /**
@@ -349,12 +596,14 @@ fun GpsDetailsContent(gpsRouteDetails: RouteDetails?, selectedActivity: Activity
 @Composable
 fun RouteDetailsContent(
     title: String?,
+    travelMode: String,
     distance: String,
     duration: String,
     subtitle: String? = null,
     testTag: String = ""
 ) {
   Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+
     // Title Section
     title?.let {
       Text(
@@ -371,6 +620,16 @@ fun RouteDetailsContent(
           modifier = Modifier.width(1.dp).height(60.dp))
       Spacer(modifier = Modifier.width(8.dp))
       Column {
+        DetailRow(
+            icon =
+                when (travelMode.lowercase(Locale.ROOT)) {
+                  "walking" -> Icons.Filled.DirectionsWalk
+                  "driving" -> Icons.Filled.DirectionsCar
+                  "bicycling" -> Icons.Filled.DirectionsBike
+                  else -> Icons.Filled.Directions // Default icon
+                },
+            text = "Travel Mode: ${travelMode.capitalize(Locale.ROOT)}",
+            testTag = "RouteDetailsTravelMode$testTag")
         DetailRow(
             icon = Icons.Default.LocationOn,
             text = "Distance: $distance",

--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/map/ActivitiesMapScreen.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/map/ActivitiesMapScreen.kt
@@ -548,7 +548,8 @@ fun ActivityDetailsContent(
               onClick = { onShowPathGPS(activity) },
               enabled = isGPSAvailable,
               modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp)) {
-                Text("Show Path")
+                Text(
+                    if (isGPSAvailable) "Show Path to this Activity" else "Enable GPS to Show Path")
               }
         }
       }

--- a/app/src/main/java/com/github/se/travelpouch/ui/dashboard/map/ActivitiesMapScreen.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/dashboard/map/ActivitiesMapScreen.kt
@@ -162,7 +162,7 @@ fun ActivitiesMapScreen(
       })
 
   // State to track whether to show paths
-  var showPathsActivities by remember { mutableStateOf(false) }
+  var showPathsActivities by remember { mutableStateOf(true) }
   var showPathsGPS by remember { mutableStateOf(false) }
 
   // State to track the travel mode for directions
@@ -295,6 +295,14 @@ fun ActivitiesMapScreen(
 // Helper Functions for displaying the travel mode buttons
 // -------------------------------------------------
 
+/**
+ * Displays buttons for toggling paths and selecting travel modes for activities.
+ *
+ * @param showPaths Whether to show paths between activities.
+ * @param onTogglePaths Callback triggered when the paths are toggled.
+ * @param travelMode The selected travel mode for directions.
+ * @param onTravelModeChange Callback triggered when the travel mode is changed.
+ */
 @Composable
 fun TravelModeButtonActivities(
     showPaths: Boolean,
@@ -343,6 +351,15 @@ fun TravelModeButtonActivities(
       }
 }
 
+/**
+ * Displays a button for selecting a travel mode for activities.
+ *
+ * @param icon The icon to display on the button.
+ * @param contentDescription The content description for the icon.
+ * @param isActive Whether the button is currently active.
+ * @param onClick Callback triggered when the button is clicked.
+ * @param testTag A tag for identifying the composable during testing.
+ */
 @Composable
 fun TravelModesActivitiesButton(
     icon: ImageVector,
@@ -373,6 +390,12 @@ fun TravelModesActivitiesButton(
       }
 }
 
+/**
+ * Displays buttons for selecting travel modes for GPS
+ *
+ * @param selectedMode The currently selected travel mode.
+ * @param onModeSelected Callback triggered when a travel mode is selected.
+ */
 @Composable
 fun TravelModesGPS(selectedMode: String, onModeSelected: (String) -> Unit) {
   Row(
@@ -406,6 +429,15 @@ fun TravelModesGPS(selectedMode: String, onModeSelected: (String) -> Unit) {
       }
 }
 
+/**
+ * Displays a button for selecting a travel mode for GPS.
+ *
+ * @param icon The icon to display on the button.
+ * @param contentDescription The content description for the icon.
+ * @param isSelected Whether the button is currently selected.
+ * @param onClick Callback triggered when the button is clicked.
+ * @param testTag A tag for identifying the composable during testing.
+ */
 @Composable
 fun TravelModesGPSButton(
     icon: ImageVector,


### PR DESCRIPTION
This PR add the possibility of displaying paths (GPS and activities) with different modes of transport (walking, driving and cycling).

It includes : 
1. `ActivitiesScreenMap` : 4 button to choose the travel mode for the path between activities.
2. `Activity Bottom Sheet`: 1 button to show the gps path 
3.  `GPS Bottom Sheet` : 4 button to choose the travel mode for  the path between gps and activity.
