### PR TITLE
Hotfix: This fixes the invitation buttons when accepting or declining an invitation notification

### DIFF
--- a/app/src/main/java/com/github/se/travelpouch/ui/notifications/NotificationItem.kt
+++ b/app/src/main/java/com/github/se/travelpouch/ui/notifications/NotificationItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -116,6 +117,7 @@ fun InvitationButtons(
     eventsViewModel: EventViewModel
 ) {
   var buttonPressed by remember { mutableStateOf(true) }
+  LaunchedEffect(notification.notificationUid) { buttonPressed = true }
 
   Row(
       modifier = Modifier.fillMaxWidth().testTag("notification_item_buttons"),


### PR DESCRIPTION
When accepting/declining the first notification of the pile, the second one saw its buttons disabled. This was caused because the card are not constructed from zero again but are reused. Thus, the first notification disappears but the second one takes its place in the same card. So, the buttons are still disabled. We correct this throught a lauchEffect on the notification Uid. Indeed, now when the uid of a notification changes, it means that a new notification came in the card, so we need to treat it differently. Meaning that we re-enalble the invitation buttons